### PR TITLE
client: remove internal info

### DIFF
--- a/client/config_test.go
+++ b/client/config_test.go
@@ -42,8 +42,8 @@ func TestConfigOptions(t *testing.T) {
 	assert.Equal(t, "udp", transportOpts.Network)
 	assert.Equal(t, trpc.DefaultClientCodec, clientOpts.Codec)
 
-	filter.Register("tjg", filter.NoopServerFilter, filter.NoopClientFilter)
-	filter.Register("m007", filter.NoopServerFilter, filter.NoopClientFilter)
+	filter.Register("Monitoring", filter.NoopServerFilter, filter.NoopClientFilter)
+	filter.Register("Authentication", filter.NoopServerFilter, filter.NoopClientFilter)
 }
 
 func TestConfigNoDiscovery(t *testing.T) {
@@ -54,7 +54,7 @@ func TestConfigNoDiscovery(t *testing.T) {
 		Network:     "tcp",
 		Timeout:     1000,
 		Protocol:    "trpc",
-		Filter:      []string{"tjg", "m007"},
+		Filter:      []string{"Monitoring", "Authentication"},
 	}
 	err := client.RegisterClientConfig("trpc.test.nodiscovery", backconfig)
 	assert.NotNil(t, err)
@@ -68,7 +68,7 @@ func TestConfigNoServiceRouter(t *testing.T) {
 		Network:       "tcp",
 		Timeout:       1000,
 		Protocol:      "trpc",
-		Filter:        []string{"tjg", "m007"},
+		Filter:        []string{"Monitoring", "Authentication"},
 	}
 	err := client.RegisterClientConfig("trpc.test.noservicerouter", backconfig)
 	assert.NotNil(t, err)
@@ -82,7 +82,7 @@ func TestConfigNoBalance(t *testing.T) {
 		Network:     "tcp",
 		Timeout:     1000,
 		Protocol:    "trpc",
-		Filter:      []string{"tjg", "m007"},
+		Filter:      []string{"Monitoring", "Authentication"},
 	}
 	err := client.RegisterClientConfig("trpc.test.nobalance", backconfig)
 	assert.NotNil(t, err)
@@ -150,7 +150,7 @@ func TestConfigNoBreaker(t *testing.T) {
 		Network:        "tcp",
 		Timeout:        1000,
 		Protocol:       "trpc",
-		Filter:         []string{"tjg", "m007"},
+		Filter:         []string{"Monitoring", "Authentication"},
 	}
 	err := client.RegisterClientConfig("trpc.test.nobreaker", backconfig)
 	assert.NotNil(t, err)
@@ -163,7 +163,7 @@ func TestConfigNoFilter(t *testing.T) {
 		Network:     "tcp",
 		Timeout:     1000,
 		Protocol:    "trpc",
-		Filter:      []string{"tjg", "no-exists"},
+		Filter:      []string{"Monitoring", "no-exists"},
 	}
 	err := client.RegisterClientConfig("trpc.test.nofilter", backconfig)
 	assert.NotNil(t, err)
@@ -176,9 +176,9 @@ func TestConfigFilter(t *testing.T) {
 		Network:     "tcp",
 		Timeout:     1000,
 		Protocol:    "trpc",
-		Filter:      []string{"tjg"},
+		Filter:      []string{"Monitoring"},
 	}
-	filter.Register("tjg", nil, filter.NoopClientFilter)
+	filter.Register("Monitoring", nil, filter.NoopClientFilter)
 	err := client.RegisterClientConfig("trpc.test.filter", backconfig)
 	assert.Nil(t, err)
 }

--- a/client/options.go
+++ b/client/options.go
@@ -34,7 +34,7 @@ type Options struct {
 	Timeout           time.Duration // Timeout.
 
 	// Target is address of backend service: name://endpoint,
-	// also compatible with old addressing like cl5://sid cmlb://appid ip://ip:port
+	// also compatible with old addressing like ip://ip:port
 	Target   string
 	endpoint string // The same as service name if target is not set.
 
@@ -260,8 +260,8 @@ func WithReplicas(r int) Option {
 	}
 }
 
-// WithTarget returns an Option that sets target address with scheme name://endpoint,
-// like cl5://sid ons://zkname ip://ip:port.
+// WithTarget returns an Option that sets target address using schema_name://endpoint .
+// e.g. ip://ip_addr:port
 func WithTarget(t string) Option {
 	return func(o *Options) {
 		o.Target = t

--- a/client/options.go
+++ b/client/options.go
@@ -260,7 +260,7 @@ func WithReplicas(r int) Option {
 	}
 }
 
-// WithTarget returns an Option that sets target address using schema_name://endpoint .
+// WithTarget returns an Option that sets target address using URI scheme://endpoint.
 // e.g. ip://ip_addr:port
 func WithTarget(t string) Option {
 	return func(o *Options) {

--- a/client/options_test.go
+++ b/client/options_test.go
@@ -169,9 +169,9 @@ func TestOptions(t *testing.T) {
 	require.Equal(t, "trpc.test.helloworld", opts.ServiceName)
 
 	// WithTarget sets target address
-	o = client.WithTarget("cl5://111:222")
+	o = client.WithTarget("ip://0.0.0.0:8080")
 	o(opts)
-	require.Equal(t, "cl5://111:222", opts.Target)
+	require.Equal(t, "ip://0.0.0.0:8080", opts.Target)
 
 	// WithNetwork sets network of backend service: tcp or udp, tcp by default
 	o = client.WithNetwork("tcp")

--- a/naming/selector/selector.go
+++ b/naming/selector/selector.go
@@ -25,7 +25,7 @@ var (
 	selectors = make(map[string]Selector)
 )
 
-// Register registers a named Selector, such as l5, cmlb and tseer.
+// Register registers a named Selector
 func Register(name string, s Selector) {
 	selectors[name] = s
 }

--- a/naming/selector/selector.go
+++ b/naming/selector/selector.go
@@ -25,7 +25,7 @@ var (
 	selectors = make(map[string]Selector)
 )
 
-// Register registers a named Selector
+// Register registers a named Selector.
 func Register(name string, s Selector) {
 	selectors[name] = s
 }

--- a/testdata/client.yaml
+++ b/testdata/client.yaml
@@ -1,8 +1,8 @@
 Test.HelloServer:
-  Network: tcp # network.
-  Target: cl5://4234234:32423424 # cl5 target.
-  Timeout: 3 # ms.
+  Network: tcp # network protocol.
+  Target: ip://127.0.0.1:8080
+  Timeout: 3 # time unit: ms
 Test.HelloServer2:
-  Network: tcp # network.
-  Target: cl5://4234234:32423424 # cl5 target.
-  Timeout: 5 # ms.
+  Network: tcp # network protocol.
+  Target: ip://127.0.0.1:8081
+  Timeout: 5 # time unit: ms.

--- a/testdata/trpc_go_error.yaml
+++ b/testdata/trpc_go_error.yaml
@@ -45,7 +45,7 @@ client:                                            # configuration for client ca
     - name: trpc.test.helloworld.Greeter2          # backend service name.
       namespace: Production                        # backend service environment.
       network: tcp                                 # backend service network type, tcp or udp, configuration takes precedence.
-      target: cl5://11111:222222                   # the specific address of the backend service, generally not configures, compatible with the old routing method, (ip://127.0.0.1:8080, cl5://modid:cmdid, cmlb://appid).
+      target: ip://127.0.0.1:8080                   # the specific address of the backend service, generally not configures, compatible with the old routing method, (e.g. ip://127.0.0.1:8080).
       protocol: http                               # application layer protocol, trpc or http.
       timeout: 2000                                # maximum request processing time in milliseconds.
 
@@ -76,9 +76,6 @@ plugins:                                          # plugins configurations.
       curcuitbreaker:                             # circuit breaker configuration of polaris overall api.
         name: rate                                # circuit breaker strategy of polaris overall api.
       address_list: ${polaris_address_list}       # name service remote address list.
-    cmlb:                                         # configuration for cmlb name service.
-      refresh_interval: 10000                     # sync refresh time.
-      agent_address: ${cmlb_agent_address}        # local agent address.
 
   discovery:                                      # service discovery configuration.
     polaris:                                      # configuration for polaris service discovery.
@@ -118,8 +115,3 @@ plugins:                                          # plugins configurations.
         param: 1
       reporter:
         localAgentHostPort: localhost:6831
-    tjg:                                # tpstelemetry.
-      agent: localhost:4534
-      sample_rate: 1000                             # sampling rate.
-      min_speed_rate: 100                           # minimum speed rate.
-      max_speed_rate: 1000                          # maximum speed rate.


### PR DESCRIPTION
- remove some internal info, such as: cmlb, tjg, ons
- modify typo "schema" to "scheme"