### PR TITLE
Enable golangci check only on PR event

### DIFF
--- a/.github/workflows/prc.yml
+++ b/.github/workflows/prc.yml
@@ -28,6 +28,7 @@ jobs:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
   golangci:
     name: lint
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/setup-go@v4


### PR DESCRIPTION
golangci's only-new-issues option only takes effect during PR events, causing check failures when tagging.
https://github.com/golangci/golangci-lint-action/blob/v3.7.0/README.md?plain=1#L63