### PR TITLE
fix(example): update makefile

### DIFF
--- a/examples/helloworld/pb/Makefile
+++ b/examples/helloworld/pb/Makefile
@@ -4,5 +4,6 @@ all:
 		--rpconly \
 		--nogomod \
 		--mock=false \
+		--noservicesuffix=false
 
 .PHONY: all


### PR DESCRIPTION
not add option `--noservicesuffix=false`
![image](https://github.com/trpc-group/trpc-go/assets/6211983/c58461b6-ac7a-4eb8-9e47-8181b2ad4d3c)
