### PR TITLE
test(healthcheck): fix flaky tests by adding clean up operation in watch_test.go file

### DIFF
--- a/healthcheck/watch_test.go
+++ b/healthcheck/watch_test.go
@@ -23,10 +23,12 @@ func TestWatch(t *testing.T) {
 	require.Nil(t, watchers["testService"], "testService watcher")
 	Watch("testService", func(status Status) {})
 	require.NotNil(t, watchers["testService"], "testService watcher")
+	delete(watchers, "testService")
 }
 
 func TestGetWatchers(t *testing.T) {
 	Watch("testService", func(status Status) {})
 	ws := GetWatchers()
 	require.NotNil(t, ws["testService"])
+	delete(ws, "testService")
 }

--- a/healthcheck/watch_test.go
+++ b/healthcheck/watch_test.go
@@ -20,15 +20,17 @@ import (
 )
 
 func TestWatch(t *testing.T) {
-	require.Nil(t, watchers["testService"], "testService watcher")
-	Watch("testService", func(status Status) {})
-	require.NotNil(t, watchers["testService"], "testService watcher")
-	delete(watchers, "testService")
+	serviceName := t.Name()
+	require.Nil(t, watchers[serviceName])
+	Watch(serviceName, func(status Status) {})
+	require.NotNil(t, watchers[serviceName])
+	delete(watchers, serviceName)
 }
 
 func TestGetWatchers(t *testing.T) {
-	Watch("testService", func(status Status) {})
+	serviceName := t.Name()
+	Watch(serviceName, func(status Status) {})
 	ws := GetWatchers()
-	require.NotNil(t, ws["testService"])
-	delete(ws, "testService")
+	require.NotNil(t, ws[serviceName])
+	delete(ws, serviceName)
 }


### PR DESCRIPTION
进入/healthcheck目录

1.  执行`go test -race -failfast -timeout=0 -shuffle=on -count=1 .`发现测试时而通过时而失败
![image](https://github.com/trpc-group/trpc-go/assets/6337745/97e42bae-1dea-41d8-aba3-964ba8dd4eaa)
分析原因——测试之间有数据依赖:
使用-shuffle=on参数打乱了测试执行顺序——当先执行`TestGetWatchers`后执行`TestWatch`则导致TestWatch失败.
 2. 执行`go test -race -failfast -timeout=0 -shuffle=on -count=100 -run=TestWatch`
![image](https://github.com/trpc-group/trpc-go/assets/6337745/a99bfc20-a715-4df6-b54c-1c26f163d443)
分析原因——测试不封闭缺少Clean up阶段,所以不能重复运行
