### PR TITLE
docs: add requirements for PR labels in contribution guide

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,4 @@
-Thanks for your PR, you're awesome! 👍
+<!-- Thanks for your PR, you're awesome! 👍
 
 Please ensure you have read the [Contributing code](https://github.com/trpc-group/trpc-go/blob/main/CONTRIBUTING.md#contributing-code). 
 
@@ -10,4 +10,31 @@ The PR title should be formatted as follows: `client: remove internal info`
   - No trailing period
   - Keep the title as short as possible. ideally under 76 characters or shorter.
 
-Delete these instructions once you have read and applied them.
+Add one of the following type of label:
+type/bug: Fixes a newly discovered bug.
+type/enhancement: Adding tests, refactoring.
+type/feature: New functionality.
+type/documentation: Adds documentation.
+
+Optionally add any of the following type of label if applicable:
+type/api-change: Adds, removes, or changes an API.
+type/failing-test: CI test case is showing intermittent failures.
+type/performance: Changes that improves performance.
+type/ci: Changes the CI configuration files and scripts.
+-->
+
+<!--
+*Automatically closes linked issue when PR is merged.
+Usage: `Fixes #<issue number>`.
+-->
+Fixes #
+
+<!--
+Does this PR introduce a user-facing change?
+
+If no, just write "NONE" below.
+If yes, a release note is required, Enter your extended release note below.
+
+A release note needs a clear, concise description of the change. 
+-->
+RELEASE NOTES: NONE

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,7 +75,8 @@ Here is an example of a good one:
 > The algorithm is described at https://wikipedia.org/wiki/McGillicutty_Algorithm
 >
 > Fixes #159
-
+>
+> RELEASE NOTES: Improved precision of Sin, Cos, and Tan for very large arguments (>1e10) 
 
 #### First line
 
@@ -102,6 +103,34 @@ When this change is eventually applied, the issue tracker will automatically mar
 - If there is a corresponding issue, add either `Fixes #12345` or `Updates #12345` (the latter if this is not a complete fix) to this comment
 - If referring to a repo other than `trpc-go` you can use the `owner/repo#issue_number` syntax: `Fixes trpc-group/tnet#12345`
 
+#### PR type label
+
+The PR type label is used to help identify the types of changes going into the release over time. This may allow the Release Team to develop a better understanding of what sorts of issues we would miss with a faster release cadence.
+
+For all pull requests, one of the following PR type labels must be set:
+
+- type/bug: Fixes a newly discovered bug.
+- type/enhancement: Adding tests, refactoring.
+- type/feature: New functionality.
+- type/documentation: Adds documentation.
+- type/api-change: Adds, removes, or changes an API.
+- type/failing-test: CI test case is showing intermittent failures.
+- type/performance: Changes that improves performance.
+- type/ci: Changes the CI configuration files and scripts.
+
+#### Release notes
+
+Release notes are required for any pull request with user-visible changes, this could mean:
+
+- User facing, critical bug-fixes
+- Notable feature additions
+- Deprecations or removals
+- API changes
+- Documents additions
+
+If the current PR doesn't have user-visible changes, such as internal code refactoring or adding test cases, the release notes should be filled with 'NONE' and the changes in this PR will not be recorded in the next version's CHANGELOG. If the current PR has user-visible changes, the release notes should be filled out according to the actual situation, avoiding technical details and describing the impact of the current changes from a user's perspective as much as possible.
+
+Release notes are one of the most important reference points for users about to import or upgrade to a particular release of tRPC-Go.
 
 ## Miscellaneous topics
 

--- a/CONTRIBUTING.zh_CN.md
+++ b/CONTRIBUTING.zh_CN.md
@@ -69,6 +69,8 @@ tRPC-Go 中的提交消息遵循一套特定的约定，我们将在本节中讨
 > The algorithm is described at https://wikipedia.org/wiki/McGillicutty_Algorithm
 >
 > Fixes #159
+>
+> RELEASE NOTES: Improved precision of Sin, Cos, and Tan for very large arguments (>1e10) 
 
 #### 第一行
 
@@ -93,6 +95,35 @@ tRPC-Go 中的提交消息遵循一套特定的约定，我们将在本节中讨
 
 - 如果有相关 issue，请在此评论中添加 `Fixes #12345` 或` Updates #12345`（如果这不是完整的修复）
 - 如果涉及到的仓库不是 `trpc-go`，则可以使用 `owner/repo#issue_number` 语法：`Fixes trpc-group/tnet#12345`
+
+#### PR 类型标签
+
+PR 类型标签用于标识当前 PR 变更所属的类型，为后续发布版本提供参考。这有助于发布团队在更快的发布周期里，准确识别当前周期内所有类型的问题。
+
+对于所有 PR，必须设置以下之一的 PR 类型标签：
+
+- type/bug: 修复新发现的 bug。
+- type/enhancement: 添加测试，重构内部代码。
+- type/feature: 新功能。
+- type/documentation: 添加文档。
+- type/api-change: 添加、删除或更改 API。
+- type/failing-test: CI 测试用例偶发失败。
+- type/performance: 改进性能的变更。
+- type/ci: 更改 CI 配置文件和脚本。
+
+#### 发布说明
+
+对于任何造成用户可见更改的 PR，都需要提供发布说明。这可能包括：
+
+- 用户可见的关键 bug 修复
+- 显著的功能增加
+- 功能弃用或移除
+- API 更改
+- 文档添加
+
+如果当前 PR 没有用户可见的变更，例如代码内部重构，添加测试用例等情况，发布说明内容填为 'NONE'，这个 PR 的变更就不会记录在下个版本的 CHANGELOG 中；如果当前 PR 有用户可见的变更，发布说明内容需要按照实际情况填写，尽量不要涉及技术细节，在用户视角描述当前变更会造成的影响。
+
+发布说明是用户即将使用或升级到 tRPC-Go 特定版本时的最重要参考点之一。
 
 ## 其他主题
 


### PR DESCRIPTION
In order to generate the changlog quickly during the release process, PR guidelines needs to be further improved.

Improve the PR template and documentation, requiring the inclusion of release notes in the PR description and setting appropriate labels.

RELEASE NOTES: NONE

