### PR TITLE
client: remove the write operation on *registry.Node in LoadNodeConfig to avoid data race during selecting Node

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -393,7 +393,7 @@ func selectorFilter(ctx context.Context, req interface{}, rsp interface{}, next 
 	if err != nil {
 		return OptionsFromContext(ctx).fixTimeout(err)
 	}
-	ensureMsgRemoteAddr(msg, node.Network, node.Address)
+	ensureMsgRemoteAddr(msg, findFirstNonEmpty(node.Network, opts.Network), node.Address)
 
 	// Start to process the next filter and report.
 	begin := time.Now()

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -182,7 +182,7 @@ func TestClientFail(t *testing.T) {
 		client.WithSelectorNode(node), client.WithProtocol("fake")))
 	require.Equal(t, node.Address, "127.0.0.1:8080")
 	require.Equal(t, node.ServiceName, "127.0.0.1:8080")
-	require.Equal(t, node.Network, "tcp")
+	require.Empty(t, node.Network)
 
 	// test encode failure
 	reqBody = &codec.Body{Data: []byte("failbody")}

--- a/client/options.go
+++ b/client/options.go
@@ -695,8 +695,6 @@ func (opts *Options) LoadNodeConfig(node *registry.Node) {
 	if node.Network != "" {
 		opts.Network = node.Network
 		opts.CallOptions = append(opts.CallOptions, transport.WithDialNetwork(node.Network))
-	} else {
-		node.Network = opts.Network
 	}
 	if node.Protocol != "" {
 		WithProtocol(node.Protocol)(opts)

--- a/client/stream.go
+++ b/client/stream.go
@@ -154,7 +154,7 @@ func (s *stream) Init(ctx context.Context, opt ...Option) (*Options, error) {
 		report.SelectNodeFail.Incr()
 		return nil, err
 	}
-	ensureMsgRemoteAddr(msg, node.Network, node.Address)
+	ensureMsgRemoteAddr(msg, findFirstNonEmpty(node.Network, opts.Network), node.Address)
 	const invalidCost = -1
 	opts.Node.set(node, node.Address, invalidCost)
 	if opts.Codec == nil {
@@ -164,6 +164,15 @@ func (s *stream) Init(ctx context.Context, opt ...Option) (*Options, error) {
 	opts.CallOptions = append(opts.CallOptions, transport.WithMsg(msg))
 	s.opts = opts
 	return s.opts, nil
+}
+
+func findFirstNonEmpty(ss ...string) string {
+	for _, s := range ss {
+		if s != "" {
+			return s
+		}
+	}
+	return ""
 }
 
 // Invoke implements Stream.


### PR DESCRIPTION
cherry-pick from internal code within the company
