### PR TITLE
{client, naming}: allow selector to define its own net.Addr parser

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -16,6 +16,8 @@ package client_test
 import (
 	"context"
 	"errors"
+	"fmt"
+	"net"
 	"testing"
 	"time"
 
@@ -409,6 +411,31 @@ func TestFixTimeout(t *testing.T) {
 	})
 }
 
+func TestSelectorRemoteAddrUseUserProvidedParser(t *testing.T) {
+	selector.Register(t.Name(), &fSelector{
+		selectNode: func(s string, option ...selector.Option) (*registry.Node, error) {
+			return &registry.Node{
+				Network: t.Name(),
+				Address: t.Name(),
+				ParseAddr: func(network, address string) net.Addr {
+					return newUnresolvedAddr(network, address)
+				}}, nil
+		},
+		report: func(node *registry.Node, duration time.Duration, err error) error { return nil },
+	})
+	fake := "fake"
+	codec.Register(fake, nil, &fakeCodec{})
+	ctx := trpc.BackgroundContext()
+	require.NotNil(t, client.New().Invoke(ctx, "failbody", nil,
+		client.WithServiceName(t.Name()),
+		client.WithProtocol(fake),
+		client.WithTarget(fmt.Sprintf("%s://xxx", t.Name()))))
+	addr := trpc.Message(ctx).RemoteAddr()
+	require.NotNil(t, addr)
+	require.Equal(t, t.Name(), addr.Network())
+	require.Equal(t, t.Name(), addr.String())
+}
+
 type multiplexedTransport struct {
 	require func(context.Context, []byte, ...transport.RoundTripOption)
 	fakeTransport
@@ -526,4 +553,40 @@ func (c *fakeSelector) Select(serviceName string, opt ...selector.Option) (*regi
 
 func (c *fakeSelector) Report(node *registry.Node, cost time.Duration, err error) error {
 	return nil
+}
+
+type fSelector struct {
+	selectNode func(string, ...selector.Option) (*registry.Node, error)
+	report     func(*registry.Node, time.Duration, error) error
+}
+
+func (s *fSelector) Select(serviceName string, opts ...selector.Option) (*registry.Node, error) {
+	return s.selectNode(serviceName, opts...)
+}
+
+func (s *fSelector) Report(node *registry.Node, cost time.Duration, err error) error {
+	return s.report(node, cost, err)
+}
+
+// newUnresolvedAddr returns a new unresolvedAddr.
+func newUnresolvedAddr(network, address string) *unresolvedAddr {
+	return &unresolvedAddr{network: network, address: address}
+}
+
+var _ net.Addr = (*unresolvedAddr)(nil)
+
+// unresolvedAddr is a net.Addr which returns the original network or address.
+type unresolvedAddr struct {
+	network string
+	address string
+}
+
+// Network returns the unresolved original network.
+func (a *unresolvedAddr) Network() string {
+	return a.network
+}
+
+// String returns the unresolved original address.
+func (a *unresolvedAddr) String() string {
+	return a.address
 }

--- a/client/stream.go
+++ b/client/stream.go
@@ -162,7 +162,7 @@ func (s *stream) Init(ctx context.Context, opt ...Option) (*Options, error) {
 		report.SelectNodeFail.Incr()
 		return nil, err
 	}
-	ensureMsgRemoteAddr(msg, findFirstNonEmpty(node.Network, opts.Network), node.Address)
+	ensureMsgRemoteAddr(msg, findFirstNonEmpty(node.Network, opts.Network), node.Address, node.ParseAddr)
 	const invalidCost = -1
 	opts.Node.set(node, node.Address, invalidCost)
 	if opts.Codec == nil {

--- a/naming/registry/node.go
+++ b/naming/registry/node.go
@@ -15,6 +15,7 @@ package registry
 
 import (
 	"fmt"
+	"net"
 	"time"
 )
 
@@ -30,6 +31,9 @@ type Node struct {
 	CostTime      time.Duration // 当次请求耗时
 	EnvKey        string        // 透传的环境信息
 	Metadata      map[string]interface{}
+	// ParseAddr should be used to convert Node to net.Addr if it's not nil.
+	// See test case TestSelectorRemoteAddrUseUserProvidedParser in client package.
+	ParseAddr func(network, address string) net.Addr
 }
 
 // String returns an abbreviation information of node.


### PR DESCRIPTION
<!-- Thanks for your PR, you're awesome! 👍

Please ensure you have read the [Contributing code](https://github.com/trpc-group/trpc-go/blob/main/CONTRIBUTING.md#contributing-code). 

The PR title should be formatted as follows: `client: remove internal info`
  - The package name goes before the colon
  - The part after the colon uses the verb tense + phrase that completes the blank in,
    "This change modifies tRPC-Go to ___________"
  - Lowercase verb after the colon
  - No trailing period
  - Keep the title as short as possible. ideally under 76 characters or shorter.

Add one of the following type of label:
type/bug: Fixes a newly discovered bug.
type/enhancement: Adding tests, refactoring.
type/feature: New functionality.
type/documentation: Adds documentation.

Optionally add any of the following type of label if applicable:
type/api-change: Adds, removes, or changes an API.
type/failing-test: CI test case is showing intermittent failures.
type/performance: Changes that improves performance.
type/ci: Changes the CI configuration files and scripts.
-->
This is used to avoid unnecessary addr parse which is commonly used
in trpc-database.

To properly update the DSN library, we need to introduce this feature into
the open-source tRPC-Go.

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`.
-->

<!--
Does this PR introduce a user-facing change?

If no, just write "NONE" below.
If yes, a release note is required, Enter your extended release note below.

A release note needs a clear, concise description of the change. 
-->
RELEASE NOTES: NONE