### PR TITLE
server: fix error comparison using errors.Is

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -17,6 +17,7 @@ package client
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"time"
@@ -244,7 +245,7 @@ func callFunc(ctx context.Context, reqBody interface{}, rspBody interface{}) (er
 	}
 	rspBuf, err := opts.Transport.RoundTrip(ctx, reqBuf, opts.CallOptions...)
 	if err != nil {
-		if err == errs.ErrClientNoResponse { // Sendonly mode, no response, just return nil.
+		if errors.Is(err, errs.ErrClientNoResponse) { // Sendonly mode, no response, just return nil.
 			return nil
 		}
 		return err

--- a/server/service.go
+++ b/server/service.go
@@ -209,7 +209,7 @@ func (s *service) Handle(ctx context.Context, reqBuf []byte) (rspBuf []byte, err
 	rspbody, err := s.handle(ctx, msg, reqBodyBuf)
 	if err != nil {
 		// no response
-		if err == errs.ErrServerNoResponse {
+		if errors.Is(err, errs.ErrServerNoResponse) {
 			return nil, err
 		}
 		// failed to handle, should respond to client with error code,


### PR DESCRIPTION
server: fix error comparison using errors.Is

<!-- 
*Automatically closes linked issue when PR is merged. 
Usage: `Fixes #<issue number>`. 
-->
Fixes 

### What does this PR do?

This PR replaces the direct error comparison `err == errs.ErrServerNoResponse` with `errors.Is(err, errs.ErrServerNoResponse)` in `server/service.go` and `transport/server_transport_tcp.go`.

### Why is this change important?

Currently, the code uses `==` to check for `ErrServerNoResponse`. This is fragile because if `ErrServerNoResponse` is wrapped (e.g., using `fmt.Errorf("...%w...", err)`), the comparison will fail, causing the server to send a response when it should be silent (e.g., in One-Way calls).

Using `errors.Is` is the standard and robust way to handle error checking in Go 1.13+, allowing wrapped errors to be correctly identified.

### How to verify?

1. Wrap `errs.ErrServerNoResponse` in a handler or filter.
2. Before this fix: the server incorrectly sends a response.
3. After this fix: the server correctly suppresses the response.

<!-- 
Does this PR introduce a user-facing change? 
-->
RELEASE NOTES: NONE