### PR TITLE
all: sync selected internal bug fixes

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -12,3 +12,8 @@ extend-exclude = ["LICENSE"]
 [default.extend-identifiers]
 # Don't correct the identifiers "O_WRONLY"
 O_WRONLY = "O_WRONLY"
+StreamHandlerWapper = "StreamHandlerWapper"
+
+[default.extend-words]
+# Keep the existing exported API spelling for compatibility.
+Wapper = "Wapper"

--- a/codec/message.go
+++ b/codec/message.go
@@ -166,7 +166,7 @@ type Msg interface {
 	// but for client, is its own service.
 	WithCallerService(string)
 
-	// WithCallerMethod sets caller method, For server this mothod is upstream mothod,
+	// WithCallerMethod sets caller method, For server this method is upstream method,
 	// but for client, is its own method.
 	WithCallerMethod(string)
 

--- a/config/trpc_config.go
+++ b/config/trpc_config.go
@@ -14,6 +14,7 @@
 package config
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -389,8 +390,21 @@ func (c *TrpcConfig) Load() error {
 	if err != nil {
 		return fmt.Errorf("trpc/config failed to load error: %w config id: %s", err, c.id)
 	}
+	if c.sameData(data) {
+		return nil
+	}
 
 	return c.set(data)
+}
+
+func (c *TrpcConfig) sameData(data []byte) bool {
+	if c.value == nil {
+		return false
+	}
+	if c.expandEnv {
+		data = expandenv.ExpandEnv(data)
+	}
+	return bytes.Equal(c.value.raw, data)
 }
 
 // Reload reloads config.

--- a/config/trpc_config_test.go
+++ b/config/trpc_config_test.go
@@ -19,6 +19,7 @@ import (
 	"os"
 	"reflect"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -166,6 +167,31 @@ func TestCodecUnmarshalDstMustBeMap(t *testing.T) {
 	require.Nil(t, err)
 }
 
+func TestLoadSkipsUnmarshalWhenProviderDataUnchanged(t *testing.T) {
+	loader := newTrpcConfigLoad()
+	provider := newCountingDataProvider(t.Name())
+	codec := &countingCodec{name: t.Name()}
+	RegisterProvider(provider)
+	RegisterCodec(codec)
+
+	const path = "key"
+	provider.Set(path, []byte(`key: value`))
+	cfg, err := loader.Load(path, WithProvider(provider.Name()), WithCodec(codec.Name()))
+	require.NoError(t, err)
+	require.Equal(t, "value", cfg.GetString("key", ""))
+
+	require.NoError(t, cfg.Load())
+	require.Equal(t, "value", cfg.GetString("key", ""))
+	require.Equal(t, int64(2), provider.ReadCount())
+	require.Equal(t, int64(1), codec.UnmarshalCount())
+
+	provider.Set(path, []byte(`key: value2`))
+	require.NoError(t, cfg.Load())
+	require.Equal(t, "value2", cfg.GetString("key", ""))
+	require.Equal(t, int64(3), provider.ReadCount())
+	require.Equal(t, int64(2), codec.UnmarshalCount())
+}
+
 func NewEnvProvider(name string, data []byte) *EnvProvider {
 	return &EnvProvider{
 		name: name,
@@ -306,4 +332,54 @@ func (c dstMustBeMapCodec) Unmarshal(bts []byte, dst interface{}) error {
 		return errors.New("the dst of codec.Unmarshal must be a map")
 	}
 	return nil
+}
+
+type countingDataProvider struct {
+	readCount int64
+	name      string
+	values    sync.Map
+}
+
+func newCountingDataProvider(name string) *countingDataProvider {
+	return &countingDataProvider{name: name}
+}
+
+func (p *countingDataProvider) Name() string {
+	return p.name
+}
+
+func (p *countingDataProvider) Read(path string) ([]byte, error) {
+	atomic.AddInt64(&p.readCount, 1)
+	if v, ok := p.values.Load(path); ok {
+		return v.([]byte), nil
+	}
+	return nil, fmt.Errorf("not found config")
+}
+
+func (p *countingDataProvider) Watch(ProviderCallback) {}
+
+func (p *countingDataProvider) Set(path string, data []byte) {
+	p.values.Store(path, data)
+}
+
+func (p *countingDataProvider) ReadCount() int64 {
+	return atomic.LoadInt64(&p.readCount)
+}
+
+type countingCodec struct {
+	unmarshalCount int64
+	name           string
+}
+
+func (c *countingCodec) Name() string {
+	return c.name
+}
+
+func (c *countingCodec) Unmarshal(in []byte, out interface{}) error {
+	atomic.AddInt64(&c.unmarshalCount, 1)
+	return (&YamlCodec{}).Unmarshal(in, out)
+}
+
+func (c *countingCodec) UnmarshalCount() int64 {
+	return atomic.LoadInt64(&c.unmarshalCount)
 }

--- a/docs/user_guide/metadata_transmission.md
+++ b/docs/user_guide/metadata_transmission.md
@@ -43,7 +43,7 @@ When the server responds to the client, it can set the metadata through `ctx` to
 
 ```go
 // Note: Use the ctx passed by the framework. 
-// Set the value of the metadat key1 to []byte("val1") through this API.
+// Set the value of the metadata key1 to []byte("val1") through this API.
 trpc.SetMetaData(ctx, "key1", []byte("val1")) 
 ```
 

--- a/examples/features/rpcz/server/main.go
+++ b/examples/features/rpcz/server/main.go
@@ -68,7 +68,7 @@ func (t *testRPCZAttributeImpl) Hello(ctx context.Context, req *pb.HelloReq) (*p
 	case "Code":
 		return t.codeResult(ctx, req)
 	default:
-		return nil, errs.New(111, "unknow rpcz type")
+		return nil, errs.New(111, "unknown rpcz type")
 	}
 
 }

--- a/http/codec.go
+++ b/http/codec.go
@@ -199,6 +199,9 @@ type Header struct {
 	ReqBody  []byte
 	Request  *http.Request
 	Response http.ResponseWriter
+	// reqContentType caches the request Content-Type at Decode time so Encode
+	// does not read req.Header after user code may have observed the request.
+	reqContentType string
 }
 
 // ClientReqHeader encapsulates http client context.
@@ -442,6 +445,7 @@ func (sc *ServerCodec) Decode(msg codec.Msg, _ []byte) ([]byte, error) {
 	if head == nil {
 		return nil, errors.New("server decode missing http header in context")
 	}
+	head.reqContentType = head.Request.Header.Get("Content-Type")
 
 	reqBody, err := sc.getReqbody(head, msg)
 	if err != nil {
@@ -506,7 +510,7 @@ func (sc *ServerCodec) Encode(msg codec.Msg, rspBody []byte) (b []byte, err erro
 	rsp.Header().Add("X-Content-Type-Options", "nosniff")
 	ct := rsp.Header().Get(ctKey)
 	if ct == "" {
-		ct = req.Header.Get(ctKey)
+		ct = head.reqContentType
 		if req.Method == http.MethodGet || ct == "" {
 			ct = "application/json"
 		}

--- a/http/codec_test.go
+++ b/http/codec_test.go
@@ -279,6 +279,24 @@ func TestServerDecodeHTTPHeader(t *testing.T) {
 	require.NotNil(t, err)
 }
 
+func TestServerCodecEncodeUsesDecodedContentType(t *testing.T) {
+	r := httptest.NewRequest(http.MethodPost, "http://www.qq.com/trpc.http.test.helloworld/SayHello",
+		bytes.NewReader([]byte("{}")))
+	r.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	header := &thttp.Header{Request: r, Response: w}
+	ctx := thttp.WithHeader(context.Background(), header)
+	msg := codec.Message(ctx)
+
+	_, err := thttp.DefaultServerCodec.Decode(msg, nil)
+	require.Nil(t, err)
+
+	r.Header.Set("Content-Type", "application/proto")
+	_, err = thttp.DefaultServerCodec.Encode(msg, []byte("{}"))
+	require.Nil(t, err)
+	require.Equal(t, "application/json", w.Header().Get("Content-Type"))
+}
+
 func TestServerDecode(t *testing.T) {
 	r, _ := http.NewRequest("GET", "www.qq.com/xyz=abc", bytes.NewReader([]byte("")))
 	w := &httptest.ResponseRecorder{}

--- a/http/transport.go
+++ b/http/transport.go
@@ -314,7 +314,7 @@ func NewClientTransport(http2Only bool, opt ...transport.ClientTransportOption) 
 	return &ClientTransport{
 		opts: opts,
 		Client: stdhttp.Client{
-			Transport: NewRoundTripper(StdHTTPTransport),
+			Transport: NewRoundTripper(StdHTTPTransport.Clone()),
 		},
 		tlsClients: make(map[string]*stdhttp.Client),
 		http2Only:  http2Only,

--- a/internal/queue/queue.go
+++ b/internal/queue/queue.go
@@ -59,7 +59,7 @@ func (q *Queue[T]) Put(v T) {
 
 // Get gets an element from the queue, blocking if there is no content.
 // Put and Get can be concurrent, but not concurrent Get.
-// If done channel notify it from blocking, it will return false.
+// If done unblocks Get, it returns false only when there is no queued element.
 func (q *Queue[T]) Get() (T, bool) {
 	for {
 		q.mu.Lock()
@@ -74,6 +74,14 @@ func (q *Queue[T]) Get() (T, bool) {
 		case <-q.notify:
 			continue
 		case <-q.done:
+			q.mu.Lock()
+			if e := q.list.Front(); e != nil {
+				q.list.Remove(e)
+				q.mu.Unlock()
+				return e.Value.(T), true
+			}
+			q.waiting = false
+			q.mu.Unlock()
 			var zero T
 			return zero, false
 		}

--- a/internal/queue/queue_test.go
+++ b/internal/queue/queue_test.go
@@ -54,6 +54,54 @@ func TestQueue(t *testing.T) {
 	assert.Nil(t, e)
 }
 
+func TestQueueGetDrainsQueuedElementWhenDoneUnblocks(t *testing.T) {
+	done := make(chan struct{})
+	q := New[int](done)
+
+	result := make(chan struct {
+		value int
+		ok    bool
+	}, 1)
+	go func() {
+		value, ok := q.Get()
+		result <- struct {
+			value int
+			ok    bool
+		}{value: value, ok: ok}
+	}()
+
+	deadline := time.Now().Add(time.Second)
+	for {
+		q.mu.Lock()
+		waiting := q.waiting
+		q.mu.Unlock()
+		if waiting {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("timed out waiting for Get to block")
+		}
+		time.Sleep(time.Millisecond)
+	}
+
+	q.mu.Lock()
+	q.list.PushBack(7)
+	q.mu.Unlock()
+	close(done)
+
+	select {
+	case got := <-result:
+		assert.True(t, got.ok)
+		assert.Equal(t, 7, got.value)
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for Get to return")
+	}
+
+	value, ok := q.Get()
+	assert.False(t, ok)
+	assert.Zero(t, value)
+}
+
 // TestConcurrentQueue test queue concurrency
 func TestConcurrentQueue(t *testing.T) {
 	done := make(chan struct{})

--- a/metrics/concurrency_internal_test.go
+++ b/metrics/concurrency_internal_test.go
@@ -1,0 +1,115 @@
+//
+//
+// Tencent is pleased to support the open source community by making tRPC available.
+//
+// Copyright (C) 2023 Tencent.
+// All rights reserved.
+//
+// If you have downloaded a copy of the tRPC source code from Tencent,
+// please note that tRPC source code is licensed under the  Apache 2.0 License,
+// A copy of the Apache 2.0 License is included in this file.
+//
+//
+
+package metrics
+
+import (
+	"sync"
+	"testing"
+)
+
+type concurrentSink struct {
+	name string
+}
+
+func (s concurrentSink) Name() string {
+	return s.name
+}
+
+func (s concurrentSink) Report(Record, ...Option) error {
+	return nil
+}
+
+func isolateMetricsForTesting(t *testing.T) {
+	t.Helper()
+
+	metricsSinksMutex.Lock()
+	oldSinks := metricsSinks
+	metricsSinks = map[string]Sink{}
+	metricsSinksMutex.Unlock()
+
+	countersMutex.Lock()
+	oldCounters := counters
+	counters = map[string]ICounter{}
+	countersMutex.Unlock()
+
+	gaugesMutex.Lock()
+	oldGauges := gauges
+	gauges = map[string]IGauge{}
+	gaugesMutex.Unlock()
+
+	timersMutex.Lock()
+	oldTimers := timers
+	timers = map[string]ITimer{}
+	timersMutex.Unlock()
+
+	histogramsMutex.Lock()
+	oldHistograms := histograms
+	histograms = map[string]IHistogram{}
+	histogramsMutex.Unlock()
+
+	t.Cleanup(func() {
+		metricsSinksMutex.Lock()
+		metricsSinks = oldSinks
+		metricsSinksMutex.Unlock()
+
+		countersMutex.Lock()
+		counters = oldCounters
+		countersMutex.Unlock()
+
+		gaugesMutex.Lock()
+		gauges = oldGauges
+		gaugesMutex.Unlock()
+
+		timersMutex.Lock()
+		timers = oldTimers
+		timersMutex.Unlock()
+
+		histogramsMutex.Lock()
+		histograms = oldHistograms
+		histogramsMutex.Unlock()
+	})
+}
+
+func TestConcurrentSinkRegistrationAndReporting(t *testing.T) {
+	isolateMetricsForTesting(t)
+
+	const goroutines = 8
+	const iterations = 100
+
+	name := t.Name()
+	Histogram(name, NewValueBounds(1, 10, 100))
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines * 2)
+	for i := 0; i < goroutines; i++ {
+		i := i
+		go func() {
+			defer wg.Done()
+			for j := 0; j < iterations; j++ {
+				RegisterMetricsSink(concurrentSink{name: name + "-sink"})
+				RegisterMetricsSink(concurrentSink{name: name + "-sink-alt"})
+			}
+		}()
+		go func() {
+			defer wg.Done()
+			for j := 0; j < iterations; j++ {
+				Counter(name).IncrBy(float64(i + j))
+				Gauge(name).Set(float64(j))
+				AddSample(name, NewValueBounds(1, 10, 100), float64(j%100))
+				_ = Report(NewSingleDimensionMetrics(name, 1, PolicySUM))
+			}
+		}()
+	}
+	wg.Wait()
+}

--- a/metrics/counter.go
+++ b/metrics/counter.go
@@ -34,11 +34,12 @@ func (c *counter) Incr() {
 
 // IncrBy increases counter by v and reports for each external Sink-able systems.
 func (c *counter) IncrBy(v float64) {
-	if len(metricsSinks) == 0 {
+	sinks := snapshotMetricsSinks()
+	if len(sinks) == 0 {
 		return
 	}
 	rec := NewSingleDimensionMetrics(c.name, v, PolicySUM)
-	for _, sink := range metricsSinks {
+	for _, sink := range sinks {
 		sink.Report(rec)
 	}
 }

--- a/metrics/gauge.go
+++ b/metrics/gauge.go
@@ -26,11 +26,12 @@ type gauge struct {
 
 // Set updates the gauge value.
 func (g *gauge) Set(v float64) {
-	if len(metricsSinks) == 0 {
+	sinks := snapshotMetricsSinks()
+	if len(sinks) == 0 {
 		return
 	}
 	r := NewSingleDimensionMetrics(g.name, v, PolicySET)
-	for _, sink := range metricsSinks {
+	for _, sink := range sinks {
 		sink.Report(r)
 	}
 }

--- a/metrics/histogram.go
+++ b/metrics/histogram.go
@@ -88,12 +88,13 @@ func (h *histogram) AddSample(value float64) {
 	h.Buckets[idx].samples += value
 	h.Buckets[idx].mu.Unlock()
 
-	if len(metricsSinks) == 0 {
+	sinks := snapshotMetricsSinks()
+	if len(sinks) == 0 {
 		return
 	}
 
 	r := NewSingleDimensionMetrics(h.Name, value, PolicyHistogram)
-	for _, sink := range metricsSinks {
+	for _, sink := range sinks {
 		sink.Report(r)
 	}
 }

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -88,6 +88,19 @@ func GetMetricsSink(name string) (Sink, bool) {
 	return sink, ok
 }
 
+func snapshotMetricsSinks() []Sink {
+	metricsSinksMutex.RLock()
+	defer metricsSinksMutex.RUnlock()
+	if len(metricsSinks) == 0 {
+		return nil
+	}
+	sinks := make([]Sink, 0, len(metricsSinks))
+	for _, sink := range metricsSinks {
+		sinks = append(sinks, sink)
+	}
+	return sinks
+}
+
 // Counter creates a named counter.
 func Counter(name string) ICounter {
 	countersMutex.RLock()
@@ -230,7 +243,7 @@ func AddSample(key string, buckets BucketBounds, value float64) {
 // Report reports a multi-dimension record.
 func Report(rec Record, opts ...Option) (err error) {
 	var errs []error
-	for _, sink := range metricsSinks {
+	for _, sink := range snapshotMetricsSinks() {
 		err = sink.Report(rec, opts...)
 		if err != nil {
 			errs = append(errs, fmt.Errorf("sink-%s error: %v", sink.Name(), err))

--- a/metrics/timer.go
+++ b/metrics/timer.go
@@ -39,12 +39,13 @@ type timer struct {
 // Record records the time cost since last Record.
 func (t *timer) Record() time.Duration {
 	duration := time.Since(t.start)
-	if len(metricsSinks) == 0 {
+	sinks := snapshotMetricsSinks()
+	if len(sinks) == 0 {
 		return duration
 	}
 	t.start = time.Now()
 	r := NewSingleDimensionMetrics(t.name, float64(duration), PolicyTimer)
-	for _, sink := range metricsSinks {
+	for _, sink := range sinks {
 		sink.Report(r)
 	}
 	return duration
@@ -52,12 +53,13 @@ func (t *timer) Record() time.Duration {
 
 // RecordDuration records duration and reset t.start to now.
 func (t *timer) RecordDuration(duration time.Duration) {
-	if len(metricsSinks) == 0 {
+	sinks := snapshotMetricsSinks()
+	if len(sinks) == 0 {
 		return
 	}
 	t.start = time.Now()
 	r := NewSingleDimensionMetrics(t.name, float64(duration), PolicyTimer)
-	for _, sink := range metricsSinks {
+	for _, sink := range sinks {
 		sink.Report(r)
 	}
 }

--- a/naming/README.md
+++ b/naming/README.md
@@ -4,7 +4,7 @@ English | [中文](README.zh_CN.md)
 
 Package `naming` can register nodes under the corresponding service name. In addition to `ip:port`, the registration information will also include the running environment, container and other customized metadata information. After the caller obtains all nodes based on the service name, the routing module filters the nodes based on metadata information. Finally, the load balancing algorithm selects a node from the nodes that meet the requirements to make the final request. The name provides a unified abstraction for service management and avoids the operation and maintenance difficulties caused by directly using `ip:port`.
 
-In tRPC-Go, the `register` package defines the registration specification of the server, and `discovery`, `servicerouter`, `loadbalance`, and `circuitebreaker` together form the `slector` package and define the client's service discovery specification.
+In tRPC-Go, the `register` package defines the registration specification of the server, and `discovery`, `servicerouter`, `loadbalance`, and `circuitbreaker` together form the `selector` package and define the client's service discovery specification.
 
 ## Principle
 

--- a/naming/README.zh_CN.md
+++ b/naming/README.zh_CN.md
@@ -4,7 +4,7 @@
 
 名字服务模块可以将节点注册到对应的服务名下。注册信息除了 `ip:port` 外，还会包含运行环境、容器以及其他自定义的元数据信息。调用方根据服务名获取到所有节点后，路由模块再根据元数据信息对节点进行筛选，最后，负载均衡算法从满足要求的节点中选出一个节点来进行最终请求。名字提供了服务管理的统一抽象，避免了直接使用 `ip:port` 带来的运维困难。
 
-在 tRPC-Go 中，`register` 包定义了服务端的注册规范，`discovery`、`servicerouter`、`loadbalance`、`circuitebreaker` 则一起组成 `slector` 包并定义了客户端的服务发现规范。
+在 tRPC-Go 中，`register` 包定义了服务端的注册规范，`discovery`、`servicerouter`、`loadbalance`、`circuitbreaker` 则一起组成 `selector` 包并定义了客户端的服务发现规范。
 
 ## 原理
 

--- a/naming/loadbalance/weightroundrobin/weightroundrobin_test.go
+++ b/naming/loadbalance/weightroundrobin/weightroundrobin_test.go
@@ -24,7 +24,7 @@ import (
 func TestWrrSmoothBalancing(t *testing.T) {
 	wrr := NewWeightRoundRobin(0)
 	// weight: a: 5, b: 1, c: 1
-	// list shound be: a, a, b, a, c, a, a
+	// list should be: a, a, b, a, c, a, a
 	tests := []int{0, 0, 1, 0, 2, 0, 0}
 	for i := 0; i < 7; i++ {
 		n, err := wrr.Select("test1", list1)
@@ -73,7 +73,7 @@ func TestWrrInterval(t *testing.T) {
 func TestWrrDifferentService(t *testing.T) {
 	wrr := NewWeightRoundRobin(defaultUpdateRate)
 	// weight: a: 5, b: 1, c: 1
-	// list shound be: a, a, b, a, c, a, a
+	// list should be: a, a, b, a, c, a, a
 	tests := []int{0, 0, 1, 0, 2, 0, 0}
 	for i := 0; i < 7; i++ {
 		n, err := wrr.Select("test1", list1)

--- a/naming/selector/selector.go
+++ b/naming/selector/selector.go
@@ -16,6 +16,8 @@
 package selector
 
 import (
+	"sync"
+	"sync/atomic"
 	"time"
 
 	"trpc.group/trpc-go/trpc-go/naming/registry"
@@ -30,20 +32,47 @@ type Selector interface {
 }
 
 var (
-	selectors = make(map[string]Selector)
+	selectorsMu sync.Mutex
+	selectors   atomic.Value // stores map[string]Selector
 )
 
 // Register registers a named Selector.
 func Register(name string, s Selector) {
-	selectors[name] = s
+	selectorsMu.Lock()
+	defer selectorsMu.Unlock()
+
+	old := loadSelectors()
+	next := make(map[string]Selector, len(old)+1)
+	for k, v := range old {
+		next[k] = v
+	}
+	next[name] = s
+	selectors.Store(next)
 }
 
 // Get gets a named Selector.
 func Get(name string) Selector {
-	s := selectors[name]
-	return s
+	return loadSelectors()[name]
+}
+
+func loadSelectors() map[string]Selector {
+	m, _ := selectors.Load().(map[string]Selector)
+	if m == nil {
+		return nil
+	}
+	return m
 }
 
 func unregisterForTesting(name string) {
-	delete(selectors, name)
+	selectorsMu.Lock()
+	defer selectorsMu.Unlock()
+
+	old := loadSelectors()
+	next := make(map[string]Selector, len(old))
+	for k, v := range old {
+		if k != name {
+			next[k] = v
+		}
+	}
+	selectors.Store(next)
 }

--- a/naming/selector/selector_test.go
+++ b/naming/selector/selector_test.go
@@ -14,6 +14,8 @@
 package selector
 
 import (
+	"fmt"
+	"sync"
 	"testing"
 	"time"
 
@@ -53,4 +55,31 @@ func TestSelectorGet(t *testing.T) {
 	assert.NotNil(t, s)
 	unregisterForTesting("test-selector")
 	assert.Nil(t, Get("not_exist"))
+}
+
+func TestSelectorRegisterAndGetConcurrent(t *testing.T) {
+	const goroutines = 8
+	const iterations = 100
+
+	var wg sync.WaitGroup
+	for i := 0; i < goroutines; i++ {
+		name := fmt.Sprintf("test-selector-concurrent-%d", i)
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < iterations; j++ {
+				Register(name, &testSelector{})
+			}
+		}()
+		go func() {
+			defer wg.Done()
+			for j := 0; j < iterations; j++ {
+				_ = Get(name)
+			}
+		}()
+	}
+	wg.Wait()
+	for i := 0; i < goroutines; i++ {
+		unregisterForTesting(fmt.Sprintf("test-selector-concurrent-%d", i))
+	}
 }

--- a/pool/multiplexed/multiplexed.go
+++ b/pool/multiplexed/multiplexed.go
@@ -806,9 +806,6 @@ func (vc *VirtualConnection) Write(b []byte) error {
 // Read reads back the packet.
 // Write and Read can be concurrent, but not concurrent Read.
 func (vc *VirtualConnection) Read() ([]byte, error) {
-	if err := vc.loadErr(); err != nil {
-		return nil, err
-	}
 	rsp, ok := vc.recvQueue.Get()
 	if !ok {
 		vc.Close()

--- a/pool/multiplexed/multiplexed_test.go
+++ b/pool/multiplexed/multiplexed_test.go
@@ -674,7 +674,7 @@ func (s *msuite) TestTCPReconnectMaxReconnectCount() {
 	assert.False(s.T(), ok)
 }
 
-func (s *msuite) TestStreamMultiplexd() {
+func (s *msuite) TestStreamMultiplexed() {
 	id := atomic.AddUint32(&s.requestID, 1)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
@@ -702,7 +702,7 @@ func (s *msuite) TestStreamMultiplexd() {
 	assert.Equal(s.T(), buf, rsp)
 }
 
-func (s *msuite) TestStreamMultiplexd_Addr() {
+func (s *msuite) TestStreamMultiplexed_Addr() {
 	streamID := atomic.AddUint32(&s.requestID, 1)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
@@ -725,7 +725,7 @@ func (s *msuite) TestStreamMultiplexd_Addr() {
 	assert.Equal(s.T(), s.address, ra.String())
 }
 
-func (s *msuite) TestStreamMultiplexd_MaxVirConnPerConn() {
+func (s *msuite) TestStreamMultiplexed_MaxVirConnPerConn() {
 	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
 	defer cancel()
 
@@ -760,7 +760,7 @@ func (s *msuite) TestStreamMultiplexd_MaxVirConnPerConn() {
 	assert.Equal(s.T(), 3, len(cs.conns))
 }
 
-func (s *msuite) TestStreamMultiplexd_MaxIdleConnPerHost() {
+func (s *msuite) TestStreamMultiplexed_MaxIdleConnPerHost() {
 	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
 	defer cancel()
 

--- a/pool/multiplexed/multiplexed_test.go
+++ b/pool/multiplexed/multiplexed_test.go
@@ -488,6 +488,19 @@ func (s *msuite) TestReadErrorCleanVirtualConnection() {
 	assert.Len(s.T(), vc.conn.virConns, 0)
 }
 
+func (s *msuite) TestReadDrainsQueuedResponseAfterStoredError() {
+	vc := (&Connection{
+		virConns: make(map[uint32]*VirtualConnection),
+	}).newVirConn(context.Background(), 1)
+	want := []byte("hello")
+	vc.recvQueue.Put(want)
+	vc.storeErr(errors.New("connection closed"))
+
+	got, err := vc.Read()
+	require.NoError(s.T(), err)
+	require.Equal(s.T(), want, got)
+}
+
 func (s *msuite) TestUdpMultiplexedReadTimeout() {
 	ld := &lengthDelimitedFramer{}
 
@@ -947,6 +960,19 @@ func (s *msuite) TestMultiplexedReconnectOnWriteError() {
 	require.Nil(s.T(), err)
 	vc, ok := mc.(*VirtualConnection)
 	assert.True(s.T(), ok)
+	var rawConn net.Conn
+	require.Eventually(s.T(), func() bool {
+		rawConn = vc.conn.getRawConn()
+		return rawConn != nil
+	}, time.Second, time.Millisecond)
+	writeDone := make(chan struct{})
+	vc.conn.setRawConn(&writeSignalConn{Conn: rawConn, writeDone: writeDone})
+	require.Nil(s.T(), vc.Write([]byte("hello")))
+	select {
+	case <-writeDone:
+	case <-time.After(time.Second):
+		s.T().Fatal("timed out waiting for the first write")
+	}
 	<-readTrigger                                    // Wait for the first read.
 	require.Nil(s.T(), vc.conn.getRawConn().Close()) // Now close the underlying connection.
 	require.Nil(s.T(), vc.Write([]byte("hello")))    // Then this write will trigger a reconnection on write error.
@@ -954,6 +980,20 @@ func (s *msuite) TestMultiplexedReconnectOnWriteError() {
 	require.Eventually(s.T(),
 		func() bool { return 1 == vc.conn.reconnectCount },
 		time.Second, 10*time.Millisecond)
+}
+
+type writeSignalConn struct {
+	net.Conn
+	writeDone chan struct{}
+	once      sync.Once
+}
+
+func (c *writeSignalConn) Write(b []byte) (int, error) {
+	n, err := c.Conn.Write(b)
+	c.once.Do(func() {
+		close(c.writeDone)
+	})
+	return n, err
 }
 
 func TestMultiplexedDestroyMayCauseGoroutineLeak(t *testing.T) {

--- a/test/metadata_test.go
+++ b/test/metadata_test.go
@@ -46,7 +46,7 @@ func (s *TestSuite) TestClientWithMetaDataOption() {
 			s.Run(e.String(), func() {
 				s.startServer(&TRPCService{}, server.WithFilter(
 					func(ctx context.Context, req interface{}, next filter.ServerHandleFunc) (interface{}, error) {
-						return nil, fmt.Errorf("unknow error")
+						return nil, fmt.Errorf("unknown error")
 					}))
 				defer s.closeServer(nil)
 				require.NotNil(s.T(), s.testClientWithMetaDataOption())
@@ -138,7 +138,7 @@ func (s *TestSuite) TestServerSetMetaData() {
 							if value := trpc.GetMetaData(ctx, "repeat-value"); len(value) != 0 {
 								trpc.SetMetaData(ctx, "repeat-value", append(value, value...))
 							}
-							return nil, fmt.Errorf("unknow error")
+							return nil, fmt.Errorf("unknown error")
 						}),
 				)
 				defer s.closeServer(nil)
@@ -195,7 +195,7 @@ func (s *TestSuite) TestMessageWithServerMetaDataOption() {
 			s.Run(e.String(), func() {
 				s.startServer(&TRPCService{}, server.WithFilter(
 					func(ctx context.Context, req interface{}, next filter.ServerHandleFunc) (interface{}, error) {
-						return nil, fmt.Errorf("unknow error")
+						return nil, fmt.Errorf("unknown error")
 					}))
 				defer s.closeServer(nil)
 				require.NotNil(s.T(), s.testMessageWithServerMetaDataOption())

--- a/transport/client_transport_stream.go
+++ b/transport/client_transport_stream.go
@@ -114,7 +114,7 @@ func (c *clientStreamTransport) Init(ctx context.Context, roundTripOpts ...Round
 	conn, err := opts.Multiplexed.GetMuxConn(ctx, opts.Network, opts.Address, getOpts)
 	if err != nil {
 		return errs.NewFrameError(errs.RetClientConnectFail,
-			"tcp client transport multiplexd pool: "+err.Error())
+			"tcp client transport multiplexed pool: "+err.Error())
 	}
 	msg.WithRemoteAddr(conn.RemoteAddr())
 	msg.WithLocalAddr(conn.LocalAddr())
@@ -189,7 +189,7 @@ func (c *clientStreamTransport) getOptions(ctx context.Context,
 
 	if opts.Multiplexed == nil {
 		return nil, errs.NewFrameError(errs.RetClientConnectFail,
-			"tcp client transport: multiplexd pool empty")
+			"tcp client transport: multiplexed pool empty")
 	}
 
 	if opts.FramerBuilder == nil {

--- a/transport/client_transport_tcp.go
+++ b/transport/client_transport_tcp.go
@@ -113,10 +113,7 @@ func (c *clientTransport) dialTCP(ctx context.Context, opts *RoundTripOptions) (
 			return nil, errs.NewFrameError(errs.RetClientConnectFail,
 				"tcp client transport dial: "+err.Error())
 		}
-		if ok {
-			conn.SetDeadline(d)
-		}
-		return conn, nil
+		return c.finishDialTCP(ctx, conn, d, ok)
 	}
 
 	// Connection pool mode, get connection from pool.
@@ -132,8 +129,26 @@ func (c *clientTransport) dialTCP(ctx context.Context, opts *RoundTripOptions) (
 		return nil, errs.NewFrameError(errs.RetClientConnectFail,
 			"tcp client transport connection pool: "+err.Error())
 	}
-	if ok {
-		conn.SetDeadline(d)
+	return c.finishDialTCP(ctx, conn, d, ok)
+}
+
+func (c *clientTransport) finishDialTCP(ctx context.Context, conn net.Conn, deadline time.Time, hasDeadline bool) (net.Conn, error) {
+	if hasDeadline {
+		if err := conn.SetDeadline(deadline); err != nil {
+			_ = conn.Close()
+			return nil, errs.NewFrameError(errs.RetClientConnectFail,
+				"tcp client transport set deadline: "+err.Error())
+		}
+	}
+	if ctx.Err() == context.Canceled {
+		_ = conn.Close()
+		return nil, errs.NewFrameError(errs.RetClientCanceled,
+			"client canceled after tcp dial: "+ctx.Err().Error())
+	}
+	if ctx.Err() == context.DeadlineExceeded {
+		_ = conn.Close()
+		return nil, errs.NewFrameError(errs.RetClientTimeout,
+			"client timeout after tcp dial: "+ctx.Err().Error())
 	}
 	return conn, nil
 }

--- a/transport/client_transport_test.go
+++ b/transport/client_transport_test.go
@@ -21,6 +21,7 @@ import (
 	"math"
 	"net"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -129,6 +130,44 @@ func (c *fakeConn) SetReadDeadline(t time.Time) error {
 
 func (c *fakeConn) SetWriteDeadline(t time.Time) error {
 	return nil
+}
+
+type setDeadlineErrorConn struct {
+	fakeConn
+	closeCount int32
+}
+
+func (c *setDeadlineErrorConn) Close() error {
+	atomic.AddInt32(&c.closeCount, 1)
+	return nil
+}
+
+func (c *setDeadlineErrorConn) SetDeadline(time.Time) error {
+	return errors.New("set deadline failed")
+}
+
+type fixedConnPool struct {
+	conn net.Conn
+}
+
+func (p *fixedConnPool) Get(network string, address string, opts connpool.GetOptions) (net.Conn, error) {
+	return p.conn, nil
+}
+
+func TestTcpRoundTripClosesConnOnSetDeadlineError(t *testing.T) {
+	st := transport.NewClientTransport()
+	conn := &setDeadlineErrorConn{}
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	_, err := st.RoundTrip(ctx, []byte("hello"),
+		transport.WithDialNetwork("tcp"),
+		transport.WithDialPool(&fixedConnPool{conn: conn}),
+		transport.WithClientFramerBuilder(&trpc.FramerBuilder{}),
+		transport.WithDialAddress("127.0.0.1:8888"))
+	require.NotNil(t, err)
+	require.Equal(t, errs.RetClientConnectFail, errs.Code(err))
+	require.Equal(t, int32(1), atomic.LoadInt32(&conn.closeCount))
 }
 
 func TestTcpRoundTripReadFrameNil(t *testing.T) {


### PR DESCRIPTION
## Summary
- make metrics reporting snapshot registered sinks before iterating so concurrent sink registration does not race with reporting
- make selector registration copy-on-write so concurrent Register/Get calls are safe
- skip config unmarshal when explicit reload reads unchanged provider data
- cache decoded HTTP request Content-Type so response encoding does not read a mutable request header later
- clone the default HTTP transport for each client transport to avoid sharing mutable transport state
- close TCP connections when setting deadlines fails or the context expires after dialing
- let queue and multiplexed reads drain already queued responses when the connection is closing
- stabilize the multiplexed reconnect-on-write-error regression test
- fix existing typos that block the repository-wide typos check while preserving the exported StreamHandlerWapper spelling for compatibility

## Tests
- go test ./metrics ./config ./naming/selector
- go test -race ./metrics ./config ./naming/selector
- go test ./http ./transport ./pool/multiplexed ./internal/queue
- go test ./...
- git diff --check