### PR TITLE
all: sync selected stream and http features

### DIFF
--- a/admin/admin.go
+++ b/admin/admin.go
@@ -58,7 +58,7 @@ func init() {
 	// http.DefaultServeMux.HandleFunc("/debug/pprof/trace", pprof.Trace)
 	//
 	// Simply importing the net/http/pprof package anonymously will not work.
-	// More details see: https://git.woa.com/trpc-go/trpc-go/issues/912, and https://github.com/golang/go/issues/42834.
+	// More details see: https://github.com/golang/go/issues/42834.
 	http.DefaultServeMux = http.NewServeMux()
 }
 
@@ -152,6 +152,11 @@ func (s *Server) configRouter(r *router) *router {
 func (s *Server) Register(serviceDesc interface{}, serviceImpl interface{}) error {
 	// The admin service does not need to do anything in this registration function.
 	return nil
+}
+
+// ServiceName implements server.Service.
+func (s *Server) ServiceName() string {
+	return ServiceName
 }
 
 // RegisterHealthCheck registers a new service and returns two functions, one for unregistering the service and one for

--- a/client/client.go
+++ b/client/client.go
@@ -421,6 +421,22 @@ func selectorFilter(ctx context.Context, req interface{}, rsp interface{}, next 
 	return err
 }
 
+// streamSelectorFilter is the selector filter for streaming RPCs.
+// It selects a backend node just before establishing the stream.
+func streamSelectorFilter(ctx context.Context, desc *ClientStreamDesc, streamer Streamer) (ClientStream, error) {
+	msg := codec.Message(ctx)
+	opts := OptionsFromContext(ctx)
+	node, err := selectNode(ctx, msg, opts)
+	if err != nil {
+		report.SelectNodeFail.Incr()
+		return nil, err
+	}
+	ensureMsgRemoteAddr(msg, findFirstNonEmpty(node.Network, opts.Network), node.Address, node.ParseAddr)
+	const invalidCost = -1
+	opts.Node.set(node, node.Address, invalidCost)
+	return streamer(ctx, desc)
+}
+
 // selectNode selects a backend node by selector related options and sets the msg.
 func selectNode(ctx context.Context, msg codec.Msg, opts *Options) (*registry.Node, error) {
 	opts.SelectOptions = append(opts.SelectOptions, selector.WithContext(ctx))

--- a/client/config.go
+++ b/client/config.go
@@ -70,6 +70,8 @@ type BackendConfig struct {
 
 	TLSKey  string `yaml:"tls_key"`  // Client TLS key.
 	TLSCert string `yaml:"tls_cert"` // Client TLS certificate.
+	// TLS certificate provider used to load certificate material.
+	TLSCertProvider string `yaml:"tls_cert_provider"`
 	// CA certificate used to validate the server cert when calling a TLS service (e.g., an HTTPS server).
 	CACert string `yaml:"ca_cert"`
 	// Server name used to validate the server (default: hostname) when calling an HTTPS server.
@@ -108,6 +110,9 @@ func (cfg *BackendConfig) genOptions() (*Options, error) {
 	opts.Transport = attemptSwitchingTransport(opts)
 	WithPassword(cfg.Password)(opts)
 	WithTLS(cfg.TLSCert, cfg.TLSKey, cfg.CACert, cfg.TLSServerName)(opts)
+	if cfg.TLSCertProvider != "" {
+		WithCertProvider(cfg.TLSCertProvider)(opts)
+	}
 	if cfg.Protocol != "" && opts.Codec == nil {
 		return nil, fmt.Errorf("codec %s not exists", cfg.Protocol)
 	}

--- a/client/options.go
+++ b/client/options.go
@@ -82,6 +82,10 @@ type Options struct {
 	RControl      RecvControl       // Receiver's flow control.
 	StreamFilters StreamFilterChain // Stream filter chain.
 
+	// EnableStreamSelectInFilter toggles selecting stream nodes inside the stream filter chain
+	// instead of during stream.Init. Disabled by default to preserve legacy behavior.
+	EnableStreamSelectInFilter bool
+
 	fixTimeout func(error) error
 
 	attachment *attachment.Attachment
@@ -447,6 +451,15 @@ func WithStreamFilter(sf StreamFilter) Option {
 	}
 }
 
+// WithEnableStreamSelectInFilter toggles selecting nodes in stream filter chain.
+// When enabled, a selector filter is appended as the last stream filter
+// and selectNode does not run during stream.Init.
+func WithEnableStreamSelectInFilter(enable bool) Option {
+	return func(o *Options) {
+		o.EnableStreamSelectInFilter = enable
+	}
+}
+
 // WithReqHead returns an Option that sets req head.
 // It's default to clone server req head from source request.
 func WithReqHead(h interface{}) Option {
@@ -499,6 +512,13 @@ func WithTLS(certFile, keyFile, caFile, serverName string) Option {
 			return
 		}
 		o.CallOptions = append(o.CallOptions, transport.WithDialTLS(certFile, keyFile, caFile, serverName))
+	}
+}
+
+// WithCertProvider returns an Option that sets the TLS certificate provider.
+func WithCertProvider(providerName string) Option {
+	return func(o *Options) {
+		o.CallOptions = append(o.CallOptions, transport.WithCertProvider(providerName))
 	}
 }
 
@@ -576,6 +596,11 @@ type optionsKey struct{}
 
 func contextWithOptions(ctx context.Context, opts *Options) context.Context {
 	return context.WithValue(ctx, optionsKey{}, opts)
+}
+
+// ContextWithOptions attaches the provided Options into ctx and returns the new context.
+func ContextWithOptions(ctx context.Context, opts *Options) context.Context {
+	return contextWithOptions(ctx, opts)
 }
 
 // OptionsFromContext returns options from context.

--- a/client/options_test.go
+++ b/client/options_test.go
@@ -107,6 +107,11 @@ func TestSelectOptions(t *testing.T) {
 	o(opts)
 	require.Equal(t, callOptionNum, len(opts.CallOptions))
 
+	o = client.WithCertProvider("provider")
+	callOptionNum++
+	o(opts)
+	require.Equal(t, callOptionNum, len(opts.CallOptions))
+
 	o = client.WithDisableConnectionPool()
 	callOptionNum++
 	o(opts)

--- a/client/stream.go
+++ b/client/stream.go
@@ -156,15 +156,19 @@ func (s *stream) Init(ctx context.Context, opt ...Option) (*Options, error) {
 	// Update msg.
 	s.updateMsg(msg, opts)
 
-	// Select a node of backend service.
-	node, err := selectNode(ctx, msg, opts)
-	if err != nil {
-		report.SelectNodeFail.Incr()
-		return nil, err
+	if !opts.EnableStreamSelectInFilter {
+		// Select a node of backend service.
+		node, err := selectNode(ctx, msg, opts)
+		if err != nil {
+			report.SelectNodeFail.Incr()
+			return nil, err
+		}
+		ensureMsgRemoteAddr(msg, findFirstNonEmpty(node.Network, opts.Network), node.Address, node.ParseAddr)
+		const invalidCost = -1
+		opts.Node.set(node, node.Address, invalidCost)
+	} else {
+		opts.StreamFilters = append(opts.StreamFilters, streamSelectorFilter)
 	}
-	ensureMsgRemoteAddr(msg, findFirstNonEmpty(node.Network, opts.Network), node.Address, node.ParseAddr)
-	const invalidCost = -1
-	opts.Node.set(node, node.Address, invalidCost)
 	if opts.Codec == nil {
 		report.ClientCodecEmpty.Incr()
 		return nil, errs.NewFrameError(errs.RetClientEncodeFail, "client: codec empty")

--- a/codec_stream.go
+++ b/codec_stream.go
@@ -114,6 +114,7 @@ func (c *ClientStreamCodec) decodeCloseFrame(msg codec.Msg, rspBuf []byte) ([]by
 	if err := proto.Unmarshal(rspBuf[frameHeadLen:], close); err != nil {
 		return nil, err
 	}
+	updateClientStreamCloseMeta(msg, close)
 
 	// It is considered an exception and an error should be returned to the client if:
 	// 1. the CloseType is Reset
@@ -126,9 +127,33 @@ func (c *ClientStreamCodec) decodeCloseFrame(msg codec.Msg, rspBuf []byte) ([]by
 			Msg:  string(close.GetMsg()),
 		}
 		msg.WithClientRspErr(e)
+	} else if close.GetFuncRet() != 0 {
+		msg.WithClientRspErr(errs.New(int(close.GetFuncRet()), string(close.GetMsg())))
 	}
 	msg.WithStreamFrame(close)
 	return nil, nil
+}
+
+func updateClientStreamCloseMeta(msg codec.Msg, close *trpcpb.TrpcStreamCloseMeta) {
+	if rsp, ok := msg.ClientRspHead().(*trpcpb.ResponseProtocol); ok {
+		rsp.Ret = close.GetRet()
+		rsp.FuncRet = close.GetFuncRet()
+		rsp.ErrorMsg = close.GetMsg()
+		rsp.MessageType = close.GetMessageType()
+		rsp.TransInfo = close.GetTransInfo()
+	}
+
+	if len(close.GetTransInfo()) == 0 {
+		return
+	}
+	md := msg.ClientMetaData()
+	if len(md) == 0 {
+		md = codec.MetaData{}
+	}
+	for k, v := range close.GetTransInfo() {
+		md[k] = v
+	}
+	msg.WithClientMetaData(md)
 }
 
 // decodeFeedbackFrame decodes the Feedback frame.
@@ -253,12 +278,25 @@ func (s *ServerStreamCodec) encodeCloseFrame(frameHead *FrameHead, msg codec.Msg
 	if !ok {
 		return nil, errEncodeCloseFrame
 	}
+	setStreamCloseMetaData(msg, closeFrame)
 	msg.WithStreamID(frameHead.StreamID)
 	streamBuf, err := proto.Marshal(closeFrame)
 	if err != nil {
 		return nil, err
 	}
 	return frameWrite(frameHead, streamBuf)
+}
+
+func setStreamCloseMetaData(msg codec.Msg, closeFrame *trpcpb.TrpcStreamCloseMeta) {
+	if len(msg.ServerMetaData()) == 0 {
+		return
+	}
+	if closeFrame.TransInfo == nil {
+		closeFrame.TransInfo = make(map[string][]byte)
+	}
+	for k, v := range msg.ServerMetaData() {
+		closeFrame.TransInfo[k] = v
+	}
 }
 
 // encodeDataFrame encodes the Data frame.

--- a/codec_stream_test.go
+++ b/codec_stream_test.go
@@ -325,6 +325,50 @@ func TestStreamCodecClose(t *testing.T) {
 
 }
 
+func TestStreamCodecCloseMetadata(t *testing.T) {
+	serverCodec := codec.GetServer("trpc")
+	clientCodec := codec.GetClient("trpc")
+	laddr, err := net.ResolveTCPAddr("tcp", "127.0.0.1:10000")
+	require.Nil(t, err)
+	raddr, err := net.ResolveTCPAddr("tcp", "127.0.0.1:10001")
+	require.Nil(t, err)
+
+	frameHead := &trpc.FrameHead{
+		FrameType:       uint8(trpcpb.TrpcDataFrameType_TRPC_STREAM_FRAME),
+		StreamFrameType: uint8(trpcpb.TrpcStreamFrameType_TRPC_STREAM_FRAME_CLOSE),
+		StreamID:        100,
+	}
+	_, serverMsg := codec.WithNewMessage(context.Background())
+	serverMsg.WithFrameHead(frameHead)
+	serverMsg.WithLocalAddr(laddr)
+	serverMsg.WithRemoteAddr(raddr)
+	serverMsg.WithStreamID(100)
+	serverMsg.WithServerMetaData(codec.MetaData{"trailer-key": []byte("trailer-value")})
+	serverMsg.WithStreamFrame(&trpcpb.TrpcStreamCloseMeta{
+		CloseType:   int32(trpcpb.TrpcStreamCloseType_TRPC_STREAM_CLOSE),
+		Ret:         0,
+		FuncRet:     0,
+		MessageType: uint32(trpcpb.TrpcMessageType_TRPC_TRACE_MESSAGE),
+	})
+
+	closeBuf, err := serverCodec.Encode(serverMsg, nil)
+	require.Nil(t, err)
+
+	_, clientMsg := codec.WithNewMessage(context.Background())
+	clientMsg.WithFrameHead(frameHead)
+	clientMsg.WithLocalAddr(laddr)
+	clientMsg.WithRemoteAddr(raddr)
+	rspHead := &trpcpb.ResponseProtocol{}
+	clientMsg.WithClientRspHead(rspHead)
+
+	rsp, err := clientCodec.Decode(clientMsg, closeBuf)
+	require.Nil(t, err)
+	require.Nil(t, rsp)
+	require.Equal(t, uint32(trpcpb.TrpcMessageType_TRPC_TRACE_MESSAGE), rspHead.MessageType)
+	require.Equal(t, []byte("trailer-value"), rspHead.TransInfo["trailer-key"])
+	require.Equal(t, []byte("trailer-value"), clientMsg.ClientMetaData()["trailer-key"])
+}
+
 // TestStreamCodecReset tests stream Reset/Close frame codec.
 func TestStreamCodecReset(t *testing.T) {
 	// initMeta will be deleted from cache after TestStreamCodecClose.

--- a/config.go
+++ b/config.go
@@ -529,6 +529,7 @@ type ServiceConfig struct {
 	StreamFilter      []string `yaml:"stream_filter"`          // Stream filters for the service.
 	TLSKey            string   `yaml:"tls_key"`                // Server TLS key.
 	TLSCert           string   `yaml:"tls_cert"`               // Server TLS certificate.
+	TLSCertProvider   string   `yaml:"tls_cert_provider"`      // TLS certificate provider.
 	CACert            string   `yaml:"ca_cert"`                // CA certificate to validate client certificate.
 	ServerAsync       *bool    `yaml:"server_async,omitempty"` // Whether to enable server asynchronous mode.
 	// MaxRoutines is the maximum number of goroutines for server asynchronous mode.

--- a/http/restful_server_transport.go
+++ b/http/restful_server_transport.go
@@ -16,7 +16,6 @@ package http
 import (
 	"context"
 	"crypto/tls"
-	"crypto/x509"
 	"errors"
 	"fmt"
 	"net"
@@ -26,7 +25,10 @@ import (
 	"time"
 
 	"github.com/valyala/fasthttp"
+	"golang.org/x/net/http2"
+	"golang.org/x/net/http2/h2c"
 	"trpc.group/trpc-go/trpc-go/internal/reuseport"
+	itls "trpc.group/trpc-go/trpc-go/internal/tls"
 	trpcpb "trpc.group/trpc/trpc-protocol/pb/go/trpc"
 
 	"trpc.group/trpc-go/trpc-go/codec"
@@ -133,6 +135,9 @@ func (st *RESTServerTransport) ListenAndServe(ctx context.Context, opt ...transp
 	for _, o := range opt {
 		o(opts)
 	}
+	if !st.basedOnFastHTTP && st.opts.EnableH2C && (len(opts.TLSKeyFile) != 0 || len(opts.TLSCertFile) != 0) {
+		return errors.New("restful server transport h2c and tls cannot be enabled at the same time")
+	}
 	// Get listener.
 	ln := opts.Listener
 	if ln == nil {
@@ -198,6 +203,17 @@ func (st *RESTServerTransport) serve(
 	}
 	// Based on net/http.
 	server := &http.Server{Addr: opts.Address, Handler: router}
+	if st.opts.EnableH2C && (len(opts.TLSKeyFile) != 0 || len(opts.TLSCertFile) != 0) {
+		return errors.New("restful server transport h2c and tls cannot be enabled at the same time")
+	}
+	if st.opts.EnableH2C {
+		server.Handler = h2c.NewHandler(router, newHTTP2Server(st.opts.HTTP2Config))
+	}
+	if st.opts.HTTP2Config != nil {
+		if err := http2.ConfigureServer(server, newHTTP2Server(st.opts.HTTP2Config)); err != nil {
+			return fmt.Errorf("restful server configure http2 error:%w", err)
+		}
+	}
 	go func() {
 		_ = server.Serve(ln)
 	}()
@@ -249,30 +265,5 @@ func (st *RESTServerTransport) getListener(opts *transport.ListenServeOptions) (
 
 // generateTLSConfig generates config of tls.
 func generateTLSConfig(opts *transport.ListenServeOptions) (*tls.Config, error) {
-	tlsConf := &tls.Config{}
-
-	cert, err := tls.LoadX509KeyPair(opts.TLSCertFile, opts.TLSKeyFile)
-	if err != nil {
-		return nil, err
-	}
-	tlsConf.Certificates = []tls.Certificate{cert}
-
-	// Two-way authentication.
-	if opts.CACertFile != "" {
-		tlsConf.ClientAuth = tls.RequireAndVerifyClientCert
-		if opts.CACertFile != "root" {
-			ca, err := os.ReadFile(opts.CACertFile)
-			if err != nil {
-				return nil, err
-			}
-			pool := x509.NewCertPool()
-			ok := pool.AppendCertsFromPEM(ca)
-			if !ok {
-				return nil, errors.New("failed to append certs from pem")
-			}
-			tlsConf.ClientCAs = pool
-		}
-	}
-
-	return tlsConf, nil
+	return itls.GetServerConfig(opts.CACertFile, opts.TLSCertFile, opts.TLSKeyFile, opts.TLSCertProvider)
 }

--- a/http/restful_server_transport_test.go
+++ b/http/restful_server_transport_test.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"github.com/valyala/fasthttp"
+	"golang.org/x/net/http2"
 
 	trpc "trpc.group/trpc-go/trpc-go"
 	"trpc.group/trpc-go/trpc-go/codec"
@@ -99,7 +100,7 @@ func TestCompatibility(t *testing.T) {
 func TestEnableTLS(t *testing.T) {
 	// Registers service.
 	s := &server.Server{}
-	conf, err := itls.GetServerConfig("../testdata/ca.pem", "../testdata/server.crt", "../testdata/server.key")
+	conf, err := itls.GetServerConfig("../testdata/ca.pem", "../testdata/server.crt", "../testdata/server.key", "")
 	require.Nil(t, err, "%+v", err)
 	ln, err := tls.Listen("tcp", "127.0.0.1:0", conf)
 	require.Nil(t, err)
@@ -157,6 +158,65 @@ func TestEnableTLS(t *testing.T) {
 	respBody := &responseBody{}
 	json.Unmarshal(bodyBytes, respBody)
 	require.Equal(t, respBody.Message, "test restful server transport")
+}
+
+func TestRESTH2C(t *testing.T) {
+	serviceName := "trpc.test.helloworld.Greeter" + t.Name()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.Nil(t, err)
+	defer ln.Close()
+
+	s := &server.Server{}
+	service := server.New(
+		server.WithListener(ln),
+		server.WithServiceName(serviceName),
+		server.WithProtocol("restful"),
+		server.WithTransport(thttp.NewRESTServerTransport(
+			false,
+			transport.WithEnableH2C(true),
+			transport.WithHTTP2Config(&transport.HTTP2Config{MaxConcurrentStreams: 10}),
+		)),
+	)
+	s.AddService(serviceName, service)
+	helloworld.RegisterGreeterService(s, &greeterServerImpl{})
+
+	go func() { require.Nil(t, s.Serve()) }()
+	defer s.Close(nil)
+	time.Sleep(100 * time.Millisecond)
+
+	cli := &http.Client{
+		Transport: &http2.Transport{
+			AllowHTTP: true,
+			DialTLS: func(network, addr string, _ *tls.Config) (net.Conn, error) {
+				return net.Dial(network, addr)
+			},
+		},
+	}
+	req, err := http.NewRequest("POST", "http://"+ln.Addr().String()+"/v1/foobar",
+		bytes.NewBuffer([]byte(`{"name": "xyz"}`)))
+	require.Nil(t, err)
+	resp, err := cli.Do(req)
+	require.Nil(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.Equal(t, "HTTP/2.0", resp.Proto)
+}
+
+func TestRESTH2CWithTLSReturnsError(t *testing.T) {
+	serviceName := "trpc.test.helloworld.Greeter" + t.Name()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.Nil(t, err)
+	defer ln.Close()
+	restful.RegisterRouter(serviceName, restful.NewRouter())
+
+	st := thttp.NewRESTServerTransport(false, transport.WithEnableH2C(true))
+	err = st.ListenAndServe(
+		context.Background(),
+		transport.WithListener(ln),
+		transport.WithServiceName(serviceName),
+		transport.WithServeTLS("../testdata/server.crt", "../testdata/server.key", ""),
+	)
+	require.ErrorContains(t, err, "h2c and tls cannot be enabled at the same time")
 }
 
 func TestReplaceRouter(t *testing.T) {

--- a/http/tls/tls.go
+++ b/http/tls/tls.go
@@ -1,0 +1,44 @@
+//
+//
+// Tencent is pleased to support the open source community by making tRPC available.
+//
+// Copyright (C) 2023 Tencent.
+// All rights reserved.
+//
+// If you have downloaded a copy of the tRPC source code from Tencent,
+// please note that tRPC source code is licensed under the  Apache 2.0 License,
+// A copy of the Apache 2.0 License is included in this file.
+//
+//
+
+// Package tls supports custom certificate providers for HTTP TLS.
+package tls
+
+import "sync"
+
+// CertificateProvider loads certificate and key material by ID.
+type CertificateProvider interface {
+	LoadCertFile(certID string) ([]byte, error)
+	LoadKeyFile(keyID string) ([]byte, error)
+}
+
+var providers sync.Map
+
+// RegisterCertificateProvider registers a CertificateProvider by name.
+func RegisterCertificateProvider(name string, provider CertificateProvider) {
+	providers.Store(name, provider)
+}
+
+// UnregisterCertificateProvider unregisters a CertificateProvider by name.
+func UnregisterCertificateProvider(name string) {
+	providers.Delete(name)
+}
+
+// GetCertificateProvider returns a registered CertificateProvider by name.
+func GetCertificateProvider(name string) CertificateProvider {
+	provider, ok := providers.Load(name)
+	if !ok {
+		return nil
+	}
+	return provider.(CertificateProvider)
+}

--- a/http/tls/tls_test.go
+++ b/http/tls/tls_test.go
@@ -1,0 +1,38 @@
+//
+//
+// Tencent is pleased to support the open source community by making tRPC available.
+//
+// Copyright (C) 2023 Tencent.
+// All rights reserved.
+//
+// If you have downloaded a copy of the tRPC source code from Tencent,
+// please note that tRPC source code is licensed under the  Apache 2.0 License,
+// A copy of the Apache 2.0 License is included in this file.
+//
+//
+
+package tls
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type testProvider struct{}
+
+func (testProvider) LoadCertFile(string) ([]byte, error) { return nil, nil }
+func (testProvider) LoadKeyFile(string) ([]byte, error)  { return nil, nil }
+
+func TestCertificateProvider(t *testing.T) {
+	const providerName = "test_provider"
+	UnregisterCertificateProvider(providerName)
+	require.Nil(t, GetCertificateProvider(providerName))
+
+	provider := testProvider{}
+	RegisterCertificateProvider(providerName, provider)
+	require.Equal(t, provider, GetCertificateProvider(providerName))
+
+	UnregisterCertificateProvider(providerName)
+	require.Nil(t, GetCertificateProvider(providerName))
+}

--- a/http/transport.go
+++ b/http/transport.go
@@ -19,7 +19,6 @@ package http
 import (
 	"bytes"
 	"context"
-	"crypto/tls"
 	"encoding/base64"
 	"errors"
 	"fmt"
@@ -73,9 +72,10 @@ var DefaultHTTP2ServerTransport transport.ServerTransport
 
 // ServerTransport is the http transport layer.
 type ServerTransport struct {
-	newServer func() *stdhttp.Server
-	reusePort bool
-	enableH2C bool
+	newServer   func() *stdhttp.Server
+	reusePort   bool
+	enableH2C   bool
+	http2Config *transport.HTTP2Config
 }
 
 // NewServerTransport creates a new ServerTransport which implement transport.ServerTransport.
@@ -179,8 +179,8 @@ func (t *ServerTransport) serve(ctx context.Context, s *stdhttp.Server, opts *tr
 		go func() {
 			if err := s.ServeTLS(
 				tcpKeepAliveListener{ln.(*net.TCPListener)},
-				opts.TLSCertFile,
-				opts.TLSKeyFile,
+				"",
+				"",
 			); err != stdhttp.ErrServerClosed {
 				log.Errorf("serve TLS failed: %w", err)
 			}
@@ -246,19 +246,25 @@ func (t *ServerTransport) newHTTPServer(
 	s.Addr = opts.Address
 	s.Handler = stdhttp.HandlerFunc(serveFunc)
 	if t.enableH2C {
-		h2s := &http2.Server{}
+		h2s := newHTTP2Server(t.http2Config)
 		s.Handler = h2c.NewHandler(stdhttp.HandlerFunc(serveFunc), h2s)
-		return s, nil
 	}
-	if len(opts.CACertFile) != 0 { // Enable two-way authentication to verify client certificate.
-		s.TLSConfig = &tls.Config{
-			ClientAuth: tls.RequireAndVerifyClientCert,
-		}
-		certPool, err := itls.GetCertPool(opts.CACertFile)
+	if len(opts.TLSKeyFile) != 0 && len(opts.TLSCertFile) != 0 {
+		tlsConf, err := itls.GetServerConfig(
+			opts.CACertFile,
+			opts.TLSCertFile,
+			opts.TLSKeyFile,
+			opts.TLSCertProvider,
+		)
 		if err != nil {
-			return nil, fmt.Errorf("http server get ca cert file error:%v", err)
+			return nil, fmt.Errorf("http server get tls config error:%v", err)
 		}
-		s.TLSConfig.ClientCAs = certPool
+		s.TLSConfig = tlsConf
+	}
+	if t.http2Config != nil {
+		if err := http2.ConfigureServer(s, newHTTP2Server(t.http2Config)); err != nil {
+			return nil, fmt.Errorf("http server configure http2 error:%w", err)
+		}
 	}
 	if opts.DisableKeepAlives {
 		s.SetKeepAlivesEnabled(false)
@@ -267,6 +273,23 @@ func (t *ServerTransport) newHTTPServer(
 		s.IdleTimeout = opts.IdleTimeout
 	}
 	return s, nil
+}
+
+func newHTTP2Server(config *transport.HTTP2Config) *http2.Server {
+	s := &http2.Server{}
+	if config == nil {
+		return s
+	}
+	s.MaxConcurrentStreams = uint32(config.MaxConcurrentStreams)
+	s.MaxDecoderHeaderTableSize = uint32(config.MaxDecoderHeaderTableSize)
+	s.MaxEncoderHeaderTableSize = uint32(config.MaxEncoderHeaderTableSize)
+	s.MaxReadFrameSize = uint32(config.MaxReadFrameSize)
+	s.PermitProhibitedCipherSuites = config.PermitProhibitedCipherSuites
+	s.IdleTimeout = config.IdleTimeout
+	s.MaxUploadBufferPerConnection = int32(config.MaxReceiveBufferPerConnection)
+	s.MaxUploadBufferPerStream = int32(config.MaxReceiveBufferPerStream)
+	s.CountError = config.CountError
+	return s
 }
 
 // tcpKeepAliveListener sets TCP keep-alive timeouts on accepted
@@ -501,7 +524,7 @@ func (ct *ClientTransport) RoundTrip(
 	request := req.WithContext(httptrace.WithClientTrace(reqCtx, trace))
 
 	client, err := ct.getStdHTTPClient(opts.CACertFile, opts.TLSCertFile,
-		opts.TLSKeyFile, opts.TLSServerName)
+		opts.TLSKeyFile, opts.TLSServerName, opts.TLSCertProvider)
 	if err != nil {
 		return nil, err
 	}
@@ -568,12 +591,12 @@ func (b *responseBodyWithCancel) Close() error {
 }
 
 func (ct *ClientTransport) getStdHTTPClient(caFile, certFile,
-	keyFile, serverName string) (*stdhttp.Client, error) {
+	keyFile, serverName, providerName string) (*stdhttp.Client, error) {
 	if len(caFile) == 0 { // HTTP requests share one client.
 		return &ct.Client, nil
 	}
 
-	cacheKey := fmt.Sprintf("%s-%s-%s", caFile, certFile, serverName)
+	cacheKey := fmt.Sprintf("%s-%s-%s-%s", caFile, certFile, serverName, providerName)
 	ct.tlsLock.RLock()
 	cli, ok := ct.tlsClients[cacheKey]
 	ct.tlsLock.RUnlock()
@@ -588,7 +611,7 @@ func (ct *ClientTransport) getStdHTTPClient(caFile, certFile,
 		return cli, nil
 	}
 
-	conf, err := itls.GetClientConfig(serverName, caFile, certFile, keyFile)
+	conf, err := itls.GetClientConfig(serverName, caFile, certFile, keyFile, providerName)
 	if err != nil {
 		return nil, err
 	}

--- a/http/transport.go
+++ b/http/transport.go
@@ -23,6 +23,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"net"
 	"net/http"
 	stdhttp "net/http"
@@ -280,16 +281,36 @@ func newHTTP2Server(config *transport.HTTP2Config) *http2.Server {
 	if config == nil {
 		return s
 	}
-	s.MaxConcurrentStreams = uint32(config.MaxConcurrentStreams)
-	s.MaxDecoderHeaderTableSize = uint32(config.MaxDecoderHeaderTableSize)
-	s.MaxEncoderHeaderTableSize = uint32(config.MaxEncoderHeaderTableSize)
-	s.MaxReadFrameSize = uint32(config.MaxReadFrameSize)
+	s.MaxConcurrentStreams = http2Uint32(config.MaxConcurrentStreams)
+	s.MaxDecoderHeaderTableSize = http2Uint32(config.MaxDecoderHeaderTableSize)
+	s.MaxEncoderHeaderTableSize = http2Uint32(config.MaxEncoderHeaderTableSize)
+	s.MaxReadFrameSize = http2Uint32(config.MaxReadFrameSize)
 	s.PermitProhibitedCipherSuites = config.PermitProhibitedCipherSuites
 	s.IdleTimeout = config.IdleTimeout
-	s.MaxUploadBufferPerConnection = int32(config.MaxReceiveBufferPerConnection)
-	s.MaxUploadBufferPerStream = int32(config.MaxReceiveBufferPerStream)
+	s.MaxUploadBufferPerConnection = http2Int32(config.MaxReceiveBufferPerConnection)
+	s.MaxUploadBufferPerStream = http2Int32(config.MaxReceiveBufferPerStream)
 	s.CountError = config.CountError
 	return s
+}
+
+func http2Uint32(v int) uint32 {
+	if v <= 0 {
+		return 0
+	}
+	if int64(v) > math.MaxUint32 {
+		return math.MaxUint32
+	}
+	return uint32(v)
+}
+
+func http2Int32(v int) int32 {
+	if v > math.MaxInt32 {
+		return math.MaxInt32
+	}
+	if v < math.MinInt32 {
+		return math.MinInt32
+	}
+	return int32(v)
 }
 
 // tcpKeepAliveListener sets TCP keep-alive timeouts on accepted

--- a/http/transport.go
+++ b/http/transport.go
@@ -300,7 +300,7 @@ func http2Uint32(v int) uint32 {
 	if int64(v) > math.MaxUint32 {
 		return math.MaxUint32
 	}
-	return uint32(v)
+	return uint32(v) // #nosec G115 -- v is checked to be in the uint32 range above.
 }
 
 func http2Int32(v int) int32 {

--- a/http/transport_options.go
+++ b/http/transport_options.go
@@ -13,6 +13,8 @@
 
 package http
 
+import "trpc.group/trpc-go/trpc-go/transport"
+
 // OptServerTransport modifies ServerTransport.
 type OptServerTransport func(*ServerTransport)
 
@@ -27,5 +29,12 @@ func WithReusePort() OptServerTransport {
 func WithEnableH2C() OptServerTransport {
 	return func(st *ServerTransport) {
 		st.enableH2C = true
+	}
+}
+
+// WithHTTP2Config returns an OptServerTransport which sets HTTP/2 config.
+func WithHTTP2Config(config *transport.HTTP2Config) OptServerTransport {
+	return func(st *ServerTransport) {
+		st.http2Config = config
 	}
 }

--- a/http/transport_options_test.go
+++ b/http/transport_options_test.go
@@ -14,6 +14,7 @@
 package http
 
 import (
+	"math"
 	"net/http"
 	"testing"
 
@@ -30,4 +31,15 @@ func TestOptServerTransport(t *testing.T) {
 	require.True(t, st.reusePort)
 	require.True(t, st.enableH2C)
 	require.Equal(t, 1, st.http2Config.MaxConcurrentStreams)
+}
+
+func TestNewHTTP2ServerConfigBounds(t *testing.T) {
+	s := newHTTP2Server(&transport.HTTP2Config{
+		MaxConcurrentStreams:          -1,
+		MaxDecoderHeaderTableSize:     math.MaxInt,
+		MaxReceiveBufferPerConnection: math.MaxInt,
+	})
+	require.Equal(t, uint32(0), s.MaxConcurrentStreams)
+	require.Equal(t, uint32(math.MaxUint32), s.MaxDecoderHeaderTableSize)
+	require.Equal(t, int32(math.MaxInt32), s.MaxUploadBufferPerConnection)
 }

--- a/http/transport_options_test.go
+++ b/http/transport_options_test.go
@@ -18,13 +18,16 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"trpc.group/trpc-go/trpc-go/transport"
 )
 
 func TestOptServerTransport(t *testing.T) {
 	st := NewServerTransport(
 		func() *http.Server { return &http.Server{} },
 		WithReusePort(),
-		WithEnableH2C())
+		WithEnableH2C(),
+		WithHTTP2Config(&transport.HTTP2Config{MaxConcurrentStreams: 1}))
 	require.True(t, st.reusePort)
 	require.True(t, st.enableH2C)
+	require.Equal(t, 1, st.http2Config.MaxConcurrentStreams)
 }

--- a/http/transport_test.go
+++ b/http/transport_test.go
@@ -187,34 +187,17 @@ func TestErrHeaderHandler(t *testing.T) {
 
 func TestListenAndServeFailedDueToBadCertificationFile(t *testing.T) {
 	ctx := context.Background()
-	oldLogger := log.DefaultLogger
-	defer func() {
-		log.DefaultLogger = oldLogger
-	}()
-	errorCh := make(chan error)
-	log.DefaultLogger = &testLog{Logger: oldLogger, errorCh: errorCh}
-
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	require.Nil(t, err)
 	defer func() { require.Nil(t, ln.Close()) }()
 	const badCertFile = "bad-file.cert"
-	require.Nil(
-		t,
-		thttp.NewServerTransport(newNoopStdHTTPServer).ListenAndServe(
-			ctx,
-			transport.WithListener(ln),
-			transport.WithHandler(transport.Handler(&h{})),
-			transport.WithServeTLS(badCertFile, "../testdata/server.key", ""),
-		),
-		"failed to new client transport",
+	err = thttp.NewServerTransport(newNoopStdHTTPServer).ListenAndServe(
+		ctx,
+		transport.WithListener(ln),
+		transport.WithHandler(transport.Handler(&h{})),
+		transport.WithServeTLS(badCertFile, "../testdata/server.key", ""),
 	)
-
-	select {
-	case <-time.After(time.Second):
-		t.Fatal("listen on a bad cert should log an error")
-	case err := <-errorCh:
-		require.Contains(t, err.Error(), badCertFile)
-	}
+	require.ErrorContains(t, err, badCertFile)
 }
 
 func TestStartTLSServerAndNoCheckServer(t *testing.T) {
@@ -1530,6 +1513,11 @@ type mockService struct {
 func (m *mockService) Register(serviceDesc interface{}, serviceImpl interface{}) error {
 	m.desc = serviceDesc
 	return nil
+}
+
+// ServiceName returns mock service name.
+func (m *mockService) ServiceName() string {
+	return "mock"
 }
 
 // Serve runs service.

--- a/internal/tls/tls.go
+++ b/internal/tls/tls.go
@@ -20,24 +20,46 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strings"
+
+	httptls "trpc.group/trpc-go/trpc-go/http/tls"
 )
+
+const (
+	defaultProviderName = "default"
+	tlsFileSeparator    = ":"
+)
+
+type defaultProvider struct{}
+
+func (defaultProvider) LoadCertFile(certID string) ([]byte, error) {
+	return os.ReadFile(certID)
+}
+
+func (defaultProvider) LoadKeyFile(keyID string) ([]byte, error) {
+	return os.ReadFile(keyID)
+}
+
+func init() {
+	httptls.RegisterCertificateProvider(defaultProviderName, defaultProvider{})
+}
 
 // GetServerConfig gets TLS config for server.
 // If you do not need to verify the client's certificate, set the caCertFile to empty.
 // CertFile and keyFile should not be empty.
-func GetServerConfig(caCertFile, certFile, keyFile string) (*tls.Config, error) {
+func GetServerConfig(caCertFile, certFile, keyFile, providerName string) (*tls.Config, error) {
 	tlsConf := &tls.Config{}
-	cert, err := tls.LoadX509KeyPair(certFile, keyFile)
+	certs, err := LoadTLSKeyPairs(certFile, keyFile, providerName)
 	if err != nil {
 		return nil, fmt.Errorf("server load cert file error: %w", err)
 	}
-	tlsConf.Certificates = []tls.Certificate{cert}
+	tlsConf.Certificates = certs
 
 	if caCertFile == "" { // no need to verify client certificate.
 		return tlsConf, nil
 	}
 	tlsConf.ClientAuth = tls.RequireAndVerifyClientCert
-	pool, err := GetCertPool(caCertFile)
+	pool, err := GetCertPool(caCertFile, providerName)
 	if err != nil {
 		return nil, err
 	}
@@ -48,46 +70,94 @@ func GetServerConfig(caCertFile, certFile, keyFile string) (*tls.Config, error) 
 // GetClientConfig gets TLS config for client.
 // If you do not need to verify the server's certificate, set the caCertFile to "none".
 // If only one-way authentication, set the certFile and keyFile to empty.
-func GetClientConfig(serverName, caCertFile, certFile, keyFile string) (*tls.Config, error) {
+func GetClientConfig(serverName, caCertFile, certFile, keyFile, providerName string) (*tls.Config, error) {
 	tlsConf := &tls.Config{}
 	if caCertFile == "none" { // no need to verify server certificate.
 		tlsConf.InsecureSkipVerify = true
-		return tlsConf, nil
+	} else {
+		// need to verify server certification.
+		tlsConf.ServerName = serverName
+		certPool, err := GetCertPool(caCertFile, providerName)
+		if err != nil {
+			return nil, err
+		}
+		tlsConf.RootCAs = certPool
 	}
-	// need to verify server certification.
-	tlsConf.ServerName = serverName
-	certPool, err := GetCertPool(caCertFile)
-	if err != nil {
-		return nil, err
-	}
-	tlsConf.RootCAs = certPool
-	if certFile == "" {
+	if certFile == "" || keyFile == "" {
 		return tlsConf, nil
 	}
 	// enable two-way authentication and needs to send the
 	// client's own certificate to the server.
-	cert, err := tls.LoadX509KeyPair(certFile, keyFile)
+	certs, err := LoadTLSKeyPairs(certFile, keyFile, providerName)
 	if err != nil {
 		return nil, fmt.Errorf("client load cert file error: %w", err)
 	}
-	tlsConf.Certificates = []tls.Certificate{cert}
+	tlsConf.Certificates = certs
 	return tlsConf, nil
 }
 
+// LoadTLSKeyPairs loads X.509 key pairs from the provider.
+func LoadTLSKeyPairs(certFile, keyFile, providerName string) ([]tls.Certificate, error) {
+	provider, err := getProvider(providerName)
+	if err != nil {
+		return nil, err
+	}
+	certs := strings.Split(certFile, tlsFileSeparator)
+	keys := strings.Split(keyFile, tlsFileSeparator)
+	if len(certs) != len(keys) {
+		return nil, errors.New("certificate file count does not match key file count")
+	}
+
+	certificates := make([]tls.Certificate, 0, len(certs))
+	for i := range certs {
+		certPEMBlock, err := provider.LoadCertFile(certs[i])
+		if err != nil {
+			return nil, fmt.Errorf("load cert file error: %w", err)
+		}
+		keyPEMBlock, err := provider.LoadKeyFile(keys[i])
+		if err != nil {
+			return nil, fmt.Errorf("load key file error: %w", err)
+		}
+		cert, err := tls.X509KeyPair(certPEMBlock, keyPEMBlock)
+		if err != nil {
+			return nil, err
+		}
+		certificates = append(certificates, cert)
+	}
+	return certificates, nil
+}
+
 // GetCertPool gets CertPool information.
-func GetCertPool(caCertFile string) (*x509.CertPool, error) {
+func GetCertPool(caCertFile, providerName string) (*x509.CertPool, error) {
 	// root means to use the root ca certificate installed on the machine to
 	// verify the peer, if not root, use the input ca file to verify peer.
 	if caCertFile == "root" {
 		return nil, nil
 	}
-	ca, err := os.ReadFile(caCertFile)
+	provider, err := getProvider(providerName)
 	if err != nil {
-		return nil, fmt.Errorf("read ca file error: %w", err)
+		return nil, err
 	}
 	certPool := x509.NewCertPool()
-	if !certPool.AppendCertsFromPEM(ca) {
-		return nil, errors.New("AppendCertsFromPEM fail")
+	for _, file := range strings.Split(caCertFile, tlsFileSeparator) {
+		ca, err := provider.LoadCertFile(file)
+		if err != nil {
+			return nil, fmt.Errorf("read ca file error: %w", err)
+		}
+		if !certPool.AppendCertsFromPEM(ca) {
+			return nil, errors.New("AppendCertsFromPEM fail")
+		}
 	}
 	return certPool, nil
+}
+
+func getProvider(providerName string) (httptls.CertificateProvider, error) {
+	if providerName == "" {
+		providerName = defaultProviderName
+	}
+	provider := httptls.GetCertificateProvider(providerName)
+	if provider == nil {
+		return nil, fmt.Errorf("tls certificate provider %q not found", providerName)
+	}
+	return provider, nil
 }

--- a/internal/tls/tls_test.go
+++ b/internal/tls/tls_test.go
@@ -14,28 +14,86 @@
 package tls_test
 
 import (
+	"fmt"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	httptls "trpc.group/trpc-go/trpc-go/http/tls"
 	"trpc.group/trpc-go/trpc-go/internal/tls"
 )
 
 func TestGetServerConfig(t *testing.T) {
-	_, err := tls.GetServerConfig("../../testdata/ca.pem", "../../testdata/server.crt", "../../testdata/server.key")
+	_, err := tls.GetServerConfig("../../testdata/ca.pem", "../../testdata/server.crt", "../../testdata/server.key", "")
 	assert.Nil(t, err)
-	_, err = tls.GetServerConfig("", "../../testdata/server.crt", "../../testdata/server.key")
+	_, err = tls.GetServerConfig("", "../../testdata/server.crt", "../../testdata/server.key", "")
 	assert.Nil(t, err)
-	_, err = tls.GetServerConfig("", "", "")
+	_, err = tls.GetServerConfig("", "", "", "")
 	assert.NotNil(t, err)
 }
 
 func TestGetClientConfig(t *testing.T) {
-	_, err := tls.GetClientConfig("localhost", "../../testdata/ca.pem", "../../testdata/client.crt", "../../testdata/client.key")
+	_, err := tls.GetClientConfig(
+		"localhost",
+		"../../testdata/ca.pem",
+		"../../testdata/client.crt",
+		"../../testdata/client.key",
+		"",
+	)
 	assert.Nil(t, err)
-	_, err = tls.GetClientConfig("localhost", "none", "../../testdata/client.crt", "../../testdata/client.key")
+	_, err = tls.GetClientConfig("localhost", "none", "../../testdata/client.crt", "../../testdata/client.key", "")
 	assert.Nil(t, err)
-	_, err = tls.GetClientConfig("localhost", "../../testdata/ca.pem", "", "")
+	_, err = tls.GetClientConfig("localhost", "../../testdata/ca.pem", "", "", "")
 	assert.Nil(t, err)
-	_, err = tls.GetClientConfig("localhost", "root", "", "")
+	_, err = tls.GetClientConfig("localhost", "root", "", "", "")
 	assert.Nil(t, err)
+}
+
+func TestGetConfigWithProvider(t *testing.T) {
+	const providerName = "internal_tls_provider_test"
+	provider := mapProvider{
+		"ca":     readFile(t, "../../testdata/ca.pem"),
+		"server": readFile(t, "../../testdata/server.crt"),
+		"skey":   readFile(t, "../../testdata/server.key"),
+		"client": readFile(t, "../../testdata/client.crt"),
+		"ckey":   readFile(t, "../../testdata/client.key"),
+	}
+	httptls.RegisterCertificateProvider(providerName, provider)
+	defer httptls.UnregisterCertificateProvider(providerName)
+
+	serverConfig, err := tls.GetServerConfig("ca", "server", "skey", providerName)
+	require.NoError(t, err)
+	require.Len(t, serverConfig.Certificates, 1)
+	require.NotNil(t, serverConfig.ClientCAs)
+
+	clientConfig, err := tls.GetClientConfig("localhost", "ca", "client", "ckey", providerName)
+	require.NoError(t, err)
+	require.Len(t, clientConfig.Certificates, 1)
+	require.NotNil(t, clientConfig.RootCAs)
+}
+
+type mapProvider map[string][]byte
+
+func (p mapProvider) LoadCertFile(certID string) ([]byte, error) {
+	b, ok := p[certID]
+	if !ok {
+		return nil, fmt.Errorf("cert %q not found", certID)
+	}
+	return b, nil
+}
+
+func (p mapProvider) LoadKeyFile(keyID string) ([]byte, error) {
+	b, ok := p[keyID]
+	if !ok {
+		return nil, fmt.Errorf("key %q not found", keyID)
+	}
+	return b, nil
+}
+
+func readFile(t *testing.T, name string) []byte {
+	t.Helper()
+	b, err := os.ReadFile(name)
+	require.NoError(t, err)
+	return b
 }

--- a/pool/connpool/connection_pool.go
+++ b/pool/connpool/connection_pool.go
@@ -87,14 +87,15 @@ type dialFunc = func(ctx context.Context) (net.Conn, error)
 
 func (p *pool) getDialFunc(network string, address string, opts GetOptions) dialFunc {
 	dialOpts := &DialOptions{
-		Network:       network,
-		Address:       address,
-		LocalAddr:     opts.LocalAddr,
-		CACertFile:    opts.CACertFile,
-		TLSCertFile:   opts.TLSCertFile,
-		TLSKeyFile:    opts.TLSKeyFile,
-		TLSServerName: opts.TLSServerName,
-		IdleTimeout:   p.opts.IdleTimeout,
+		Network:         network,
+		Address:         address,
+		LocalAddr:       opts.LocalAddr,
+		CACertFile:      opts.CACertFile,
+		TLSCertFile:     opts.TLSCertFile,
+		TLSKeyFile:      opts.TLSKeyFile,
+		TLSCertProvider: opts.TLSCertProvider,
+		TLSServerName:   opts.TLSServerName,
+		IdleTimeout:     p.opts.IdleTimeout,
 	}
 
 	return func(ctx context.Context) (net.Conn, error) {

--- a/pool/connpool/pool.go
+++ b/pool/connpool/pool.go
@@ -32,10 +32,11 @@ type GetOptions struct {
 	CustomReader  func(io.Reader) io.Reader
 	Ctx           context.Context
 
-	CACertFile    string // ca certificate.
-	TLSCertFile   string // client certificate.
-	TLSKeyFile    string // client secret key.
-	TLSServerName string // The client verifies the server's service name,
+	CACertFile      string // ca certificate.
+	TLSCertFile     string // client certificate.
+	TLSKeyFile      string // client secret key.
+	TLSCertProvider string // provider used to load TLS certificate files.
+	TLSServerName   string // The client verifies the server's service name,
 	// if not filled in, it defaults to the http hostname.
 
 	LocalAddr   string        // The local address when establishing a connection, which is randomly selected by default.
@@ -97,6 +98,11 @@ func (o *GetOptions) WithDialTLS(certFile, keyFile, caFile, serverName string) {
 	o.TLSServerName = serverName
 }
 
+// WithCertProvider sets the TLS certificate provider.
+func (o *GetOptions) WithCertProvider(providerName string) {
+	o.TLSCertProvider = providerName
+}
+
 // WithContext returns an Option which sets the requested ctx.
 func (o *GetOptions) WithContext(ctx context.Context) {
 	o.Ctx = ctx
@@ -136,14 +142,15 @@ type DialFunc func(opts *DialOptions) (net.Conn, error)
 
 // DialOptions request parameters.
 type DialOptions struct {
-	Network       string
-	Address       string
-	LocalAddr     string
-	Timeout       time.Duration
-	CACertFile    string // ca certificate.
-	TLSCertFile   string // client certificate.
-	TLSKeyFile    string // client secret key.
-	TLSServerName string // The client verifies the server's service name,
+	Network         string
+	Address         string
+	LocalAddr       string
+	Timeout         time.Duration
+	CACertFile      string // ca certificate.
+	TLSCertFile     string // client certificate.
+	TLSKeyFile      string // client secret key.
+	TLSCertProvider string // provider used to load TLS certificate files.
+	TLSServerName   string // The client verifies the server's service name,
 	// if not filled in, it defaults to the http hostname.
 	IdleTimeout time.Duration
 }
@@ -170,7 +177,13 @@ func Dial(opts *DialOptions) (net.Conn, error) {
 		opts.TLSServerName = opts.Address
 	}
 
-	tlsConf, err := intertls.GetClientConfig(opts.TLSServerName, opts.CACertFile, opts.TLSCertFile, opts.TLSKeyFile)
+	tlsConf, err := intertls.GetClientConfig(
+		opts.TLSServerName,
+		opts.CACertFile,
+		opts.TLSCertFile,
+		opts.TLSKeyFile,
+		opts.TLSCertProvider,
+	)
 	if err != nil {
 		return nil, errs.NewFrameError(errs.RetClientDecodeFail, "client dial tls fail: "+err.Error())
 	}

--- a/pool/multiplexed/get_options.go
+++ b/pool/multiplexed/get_options.go
@@ -18,10 +18,11 @@ type GetOptions struct {
 	FP  FrameParser
 	VID uint32
 
-	CACertFile    string // CA certificate.
-	TLSCertFile   string // Client certificate.
-	TLSKeyFile    string // Client secret key.
-	TLSServerName string // The client verifies the server's service name,
+	CACertFile      string // CA certificate.
+	TLSCertFile     string // Client certificate.
+	TLSKeyFile      string // Client secret key.
+	TLSCertProvider string // Provider used to load TLS certificate files.
+	TLSServerName   string // The client verifies the server's service name,
 	// if not filled in, it defaults to the http hostname.
 
 	LocalAddr string
@@ -48,6 +49,11 @@ func (o *GetOptions) WithDialTLS(certFile, keyFile, caFile, serverName string) {
 	o.TLSKeyFile = keyFile
 	o.CACertFile = caFile
 	o.TLSServerName = serverName
+}
+
+// WithCertProvider sets the TLS certificate provider.
+func (o *GetOptions) WithCertProvider(providerName string) {
+	o.TLSCertProvider = providerName
 }
 
 // WithVID returns an Option which sets virtual connection ID.

--- a/pool/multiplexed/get_options_test.go
+++ b/pool/multiplexed/get_options_test.go
@@ -28,12 +28,14 @@ func TestGetOptions(t *testing.T) {
 	keyFile := "keyFile"
 	serverName := "serverName"
 	certFile := "certFile"
+	providerName := "providerName"
 	localAddr := "127.0.0.1:8080"
 	var id uint32 = 2
 
 	opts.WithFrameParser(fp)
 	opts.WithVID(id)
 	opts.WithDialTLS(certFile, keyFile, caFile, serverName)
+	opts.WithCertProvider(providerName)
 	opts.WithLocalAddr(localAddr)
 
 	assert.Equal(t, opts.FP, fp)
@@ -42,6 +44,7 @@ func TestGetOptions(t *testing.T) {
 	assert.Equal(t, opts.TLSKeyFile, keyFile)
 	assert.Equal(t, opts.TLSServerName, serverName)
 	assert.Equal(t, opts.TLSCertFile, certFile)
+	assert.Equal(t, opts.TLSCertProvider, providerName)
 	assert.Equal(t, opts.LocalAddr, localAddr)
 }
 

--- a/pool/multiplexed/multiplexed.go
+++ b/pool/multiplexed/multiplexed.go
@@ -206,14 +206,15 @@ func (cs *Connections) newConn(opts *GetOptions) *Connection {
 
 func dialTCP(timeout time.Duration, opts *GetOptions) (net.Conn, *connpool.DialOptions, error) {
 	dialOpts := &connpool.DialOptions{
-		Network:       opts.network,
-		Address:       opts.address,
-		Timeout:       timeout,
-		CACertFile:    opts.CACertFile,
-		TLSCertFile:   opts.TLSCertFile,
-		TLSKeyFile:    opts.TLSKeyFile,
-		TLSServerName: opts.TLSServerName,
-		LocalAddr:     opts.LocalAddr,
+		Network:         opts.network,
+		Address:         opts.address,
+		Timeout:         timeout,
+		CACertFile:      opts.CACertFile,
+		TLSCertFile:     opts.TLSCertFile,
+		TLSKeyFile:      opts.TLSKeyFile,
+		TLSCertProvider: opts.TLSCertProvider,
+		TLSServerName:   opts.TLSServerName,
+		LocalAddr:       opts.LocalAddr,
 	}
 	conn, err := tryConnect(dialOpts)
 	return conn, dialOpts, err

--- a/server/mockserver/server_mock.go
+++ b/server/mockserver/server_mock.go
@@ -60,6 +60,20 @@ func (mr *MockServiceMockRecorder) Register(serviceDesc, serviceImpl interface{}
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Register", reflect.TypeOf((*MockService)(nil).Register), serviceDesc, serviceImpl)
 }
 
+// ServiceName mocks base method
+func (m *MockService) ServiceName() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ServiceName")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// ServiceName indicates an expected call of ServiceName
+func (mr *MockServiceMockRecorder) ServiceName() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ServiceName", reflect.TypeOf((*MockService)(nil).ServiceName))
+}
+
 // Serve mocks base method
 func (m *MockService) Serve() error {
 	m.ctrl.T.Helper()

--- a/server/options.go
+++ b/server/options.go
@@ -179,6 +179,13 @@ func WithTLS(certFile, keyFile, caFile string) Option {
 	}
 }
 
+// WithCertProvider returns an Option that sets the TLS certificate provider.
+func WithCertProvider(providerName string) Option {
+	return func(o *Options) {
+		o.ServeOptions = append(o.ServeOptions, transport.WithServeCertProvider(providerName))
+	}
+}
+
 // WithNetwork returns an Option that sets network, tcp by default.
 func WithNetwork(s string) Option {
 	return func(o *Options) {

--- a/server/options_test.go
+++ b/server/options_test.go
@@ -110,6 +110,13 @@ func TestOptions(t *testing.T) {
 	}
 	assert.Equal(t, transportOpts.TLSCertFile, "server.crt")
 	assert.Equal(t, transportOpts.TLSKeyFile, "server.key")
+
+	o = server.WithCertProvider("provider")
+	o(opts)
+	for _, o := range opts.ServeOptions {
+		o(transportOpts)
+	}
+	assert.Equal(t, "provider", transportOpts.TLSCertProvider)
 }
 
 func TestMoreOptions(t *testing.T) {

--- a/server/server.go
+++ b/server/server.go
@@ -61,6 +61,11 @@ func (s *Server) Service(serviceName string) Service {
 	return s.services[serviceName]
 }
 
+// ServiceName implements Service.
+func (s *Server) ServiceName() string {
+	return ""
+}
+
 // Register implements Service interface, registering a proto service.
 // Normally, a server contains only one service, so the registration is straightforward.
 // When it comes to server with multiple services, remember to use Service("servicename") to specify

--- a/server/service.go
+++ b/server/service.go
@@ -40,6 +40,8 @@ const MaxCloseWaitTime = 10 * time.Second
 
 // Service is the interface that provides services.
 type Service interface {
+	// ServiceName returns the configured service name.
+	ServiceName() string
 	// Register registers a proto service.
 	Register(serviceDesc interface{}, serviceImpl interface{}) error
 	// Serve starts serving.
@@ -110,6 +112,14 @@ type service struct {
 	streamHandlers map[string]StreamHandler
 	streamInfo     map[string]*StreamServerInfo
 	stopListening  chan<- struct{}
+}
+
+// ServiceName returns the configured service name.
+func (s *service) ServiceName() string {
+	if s.opts == nil {
+		return ""
+	}
+	return s.opts.ServiceName
 }
 
 // New creates a service.

--- a/server/service_test.go
+++ b/server/service_test.go
@@ -193,6 +193,12 @@ func TestService(t *testing.T) {
 	assert.Nil(t, err)
 }
 
+func TestServiceName(t *testing.T) {
+	const serviceName = "trpc.test.helloworld.Greeter"
+	service := server.New(server.WithServiceName(serviceName))
+	assert.Equal(t, serviceName, service.ServiceName())
+}
+
 // TestServiceFail tests failures of request handling.
 func TestServiceFail(t *testing.T) {
 

--- a/stream/client.go
+++ b/stream/client.go
@@ -224,6 +224,9 @@ func (cs *clientStream) prepare(opt ...client.Option) error {
 		return err
 	}
 	cs.opts = opts
+	if cs.opts.EnableStreamSelectInFilter {
+		cs.ctx = client.ContextWithOptions(cs.ctx, cs.opts)
+	}
 	return nil
 }
 

--- a/stream/client_test.go
+++ b/stream/client_test.go
@@ -30,6 +30,7 @@ import (
 	"trpc.group/trpc-go/trpc-go/client"
 	"trpc.group/trpc-go/trpc-go/codec"
 	"trpc.group/trpc-go/trpc-go/errs"
+	"trpc.group/trpc-go/trpc-go/naming/registry"
 	"trpc.group/trpc-go/trpc-go/server"
 	"trpc.group/trpc-go/trpc-go/stream"
 	"trpc.group/trpc-go/trpc-go/transport"
@@ -837,4 +838,34 @@ func TestClientServerCompress(t *testing.T) {
 	err = clientStream.RecvMsg(rsp)
 	assert.Equal(t, rsp.Data, req.Data)
 	assert.Nil(t, err)
+}
+
+func TestStreamSelectInFilterSuccess(t *testing.T) {
+	codec.RegisterSerializer(0, &codec.NoopSerialization{})
+	codec.Register("fake", nil, &fakeCodec{})
+
+	tp := &fakeTransport{expectChan: make(chan recvExpect, 1)}
+	tp.expectChan <- func(fh *trpc.FrameHead, m codec.Msg) ([]byte, error) {
+		fh.StreamFrameType = uint8(trpcpb.TrpcStreamFrameType_TRPC_STREAM_FRAME_INIT)
+		m.WithStreamFrame(&trpcpb.TrpcStreamInitMeta{InitWindowSize: 0})
+		return nil, nil
+	}
+
+	var node registry.Node
+	cs, err := stream.NewStreamClient().NewStream(ctx, &client.ClientStreamDesc{}, "",
+		client.WithProtocol("fake"),
+		client.WithTarget("ip://127.0.0.1:8000"),
+		client.WithCurrentSerializationType(codec.SerializationTypeNoop),
+		client.WithStreamTransport(tp),
+		client.WithSelectorNode(&node),
+		client.WithEnableStreamSelectInFilter(true),
+	)
+	assert.Nil(t, err)
+	assert.NotNil(t, cs)
+
+	msg := codec.Message(cs.Context())
+	if assert.NotNil(t, msg.RemoteAddr()) {
+		assert.Equal(t, "127.0.0.1:8000", msg.RemoteAddr().String())
+	}
+	assert.Equal(t, "127.0.0.1:8000", node.Address)
 }

--- a/transport/client_roundtrip_options.go
+++ b/transport/client_roundtrip_options.go
@@ -38,10 +38,11 @@ type RoundTripOptions struct {
 	Msg                   codec.Msg
 	Protocol              string // protocol type
 
-	CACertFile    string // CA certificate file
-	TLSCertFile   string // client certificate file
-	TLSKeyFile    string // client key file
-	TLSServerName string // the name when client verifies the server, default as HTTP hostname
+	CACertFile      string // CA certificate file
+	TLSCertFile     string // client certificate file
+	TLSKeyFile      string // client key file
+	TLSCertProvider string // provider used to load TLS certificate files
+	TLSServerName   string // the name when client verifies the server, default as HTTP hostname
 }
 
 // ConnectionMode is the connection mode, either Connected or NotConnected.
@@ -121,6 +122,13 @@ func WithDialTLS(certFile, keyFile, caFile, serverName string) RoundTripOption {
 		opts.TLSKeyFile = keyFile
 		opts.CACertFile = caFile
 		opts.TLSServerName = serverName
+	}
+}
+
+// WithCertProvider returns a RoundTripOption which sets the TLS certificate provider.
+func WithCertProvider(providerName string) RoundTripOption {
+	return func(opts *RoundTripOptions) {
+		opts.TLSCertProvider = providerName
 	}
 }
 

--- a/transport/client_transport_stream.go
+++ b/transport/client_transport_stream.go
@@ -110,6 +110,7 @@ func (c *clientStreamTransport) Init(ctx context.Context, roundTripOpts ...Round
 	}
 	getOpts.WithFrameParser(fp)
 	getOpts.WithDialTLS(opts.TLSCertFile, opts.TLSKeyFile, opts.CACertFile, opts.TLSServerName)
+	getOpts.WithCertProvider(opts.TLSCertProvider)
 	getOpts.WithLocalAddr(opts.LocalAddr)
 	conn, err := opts.Multiplexed.GetMuxConn(ctx, opts.Network, opts.Address, getOpts)
 	if err != nil {

--- a/transport/client_transport_tcp.go
+++ b/transport/client_transport_tcp.go
@@ -100,14 +100,15 @@ func (c *clientTransport) dialTCP(ctx context.Context, opts *RoundTripOptions) (
 			timeout = opts.DialTimeout
 		}
 		conn, err = connpool.Dial(&connpool.DialOptions{
-			Network:       opts.Network,
-			Address:       opts.Address,
-			LocalAddr:     opts.LocalAddr,
-			Timeout:       timeout,
-			CACertFile:    opts.CACertFile,
-			TLSCertFile:   opts.TLSCertFile,
-			TLSKeyFile:    opts.TLSKeyFile,
-			TLSServerName: opts.TLSServerName,
+			Network:         opts.Network,
+			Address:         opts.Address,
+			LocalAddr:       opts.LocalAddr,
+			Timeout:         timeout,
+			CACertFile:      opts.CACertFile,
+			TLSCertFile:     opts.TLSCertFile,
+			TLSKeyFile:      opts.TLSKeyFile,
+			TLSCertProvider: opts.TLSCertProvider,
+			TLSServerName:   opts.TLSServerName,
 		})
 		if err != nil {
 			return nil, errs.NewFrameError(errs.RetClientConnectFail,
@@ -121,6 +122,7 @@ func (c *clientTransport) dialTCP(ctx context.Context, opts *RoundTripOptions) (
 	getOpts.WithContext(ctx)
 	getOpts.WithFramerBuilder(opts.FramerBuilder)
 	getOpts.WithDialTLS(opts.TLSCertFile, opts.TLSKeyFile, opts.CACertFile, opts.TLSServerName)
+	getOpts.WithCertProvider(opts.TLSCertProvider)
 	getOpts.WithLocalAddr(opts.LocalAddr)
 	getOpts.WithDialTimeout(opts.DialTimeout)
 	getOpts.WithProtocol(opts.Protocol)
@@ -223,6 +225,7 @@ func (c *clientTransport) multiplexed(ctx context.Context, req []byte, opts *Rou
 	}
 	getOpts.WithFrameParser(fp)
 	getOpts.WithDialTLS(opts.TLSCertFile, opts.TLSKeyFile, opts.CACertFile, opts.TLSServerName)
+	getOpts.WithCertProvider(opts.TLSCertProvider)
 	getOpts.WithLocalAddr(opts.LocalAddr)
 	conn, err := opts.Multiplexed.GetMuxConn(ctx, opts.Network, opts.Address, getOpts)
 	if err != nil {

--- a/transport/client_transport_test.go
+++ b/transport/client_transport_test.go
@@ -736,6 +736,10 @@ func TestOptions(t *testing.T) {
 	assert.Equal(t, "ca.pem", opts.CACertFile)
 	assert.Equal(t, "servername", opts.TLSServerName)
 
+	o = transport.WithCertProvider("provider")
+	o(opts)
+	assert.Equal(t, "provider", opts.TLSCertProvider)
+
 	o = transport.WithDisableConnectionPool()
 	o(opts)
 

--- a/transport/server_listenserve_options.go
+++ b/transport/server_listenserve_options.go
@@ -29,14 +29,15 @@ type ListenServeOptions struct {
 	FramerBuilder codec.FramerBuilder
 	Listener      net.Listener
 
-	CACertFile  string        // ca certification file
-	TLSCertFile string        // server certification file
-	TLSKeyFile  string        // server key file
-	Routines    int           // size of goroutine pool
-	ServerAsync bool          // whether enable server async
-	Writev      bool          // whether enable writev in server
-	CopyFrame   bool          // whether copy frame
-	IdleTimeout time.Duration // idle timeout of connection
+	CACertFile      string        // ca certification file
+	TLSCertFile     string        // server certification file
+	TLSKeyFile      string        // server key file
+	TLSCertProvider string        // provider used to load TLS certificate files
+	Routines        int           // size of goroutine pool
+	ServerAsync     bool          // whether enable server async
+	Writev          bool          // whether enable writev in server
+	CopyFrame       bool          // whether copy frame
+	IdleTimeout     time.Duration // idle timeout of connection
 
 	// DisableKeepAlives, if true, disables keep-alives and only use the
 	// connection for a single request.
@@ -100,6 +101,13 @@ func WithServeTLS(certFile, keyFile, caFile string) ListenServeOption {
 		opts.TLSCertFile = certFile
 		opts.TLSKeyFile = keyFile
 		opts.CACertFile = caFile
+	}
+}
+
+// WithServeCertProvider returns a ListenServeOption which sets the TLS certificate provider.
+func WithServeCertProvider(providerName string) ListenServeOption {
+	return func(opts *ListenServeOptions) {
+		opts.TLSCertProvider = providerName
 	}
 }
 

--- a/transport/server_transport.go
+++ b/transport/server_transport.go
@@ -233,7 +233,7 @@ func mayLiftToTLSListener(ln net.Listener, opts *ListenServeOptions) (net.Listen
 		return ln, nil
 	}
 	// Enable TLS.
-	tlsConf, err := itls.GetServerConfig(opts.CACertFile, opts.TLSCertFile, opts.TLSKeyFile)
+	tlsConf, err := itls.GetServerConfig(opts.CACertFile, opts.TLSCertFile, opts.TLSKeyFile, opts.TLSCertProvider)
 	if err != nil {
 		return nil, fmt.Errorf("tls get server config err: %w", err)
 	}

--- a/transport/server_transport_options.go
+++ b/transport/server_transport_options.go
@@ -34,6 +34,21 @@ type ServerTransportOptions struct {
 	IdleTimeout             time.Duration
 	KeepAlivePeriod         time.Duration
 	ReusePort               bool
+	EnableH2C               bool
+	HTTP2Config             *HTTP2Config
+}
+
+// HTTP2Config is the server HTTP/2 configuration.
+type HTTP2Config struct {
+	MaxConcurrentStreams          int
+	MaxDecoderHeaderTableSize     int
+	MaxEncoderHeaderTableSize     int
+	MaxReadFrameSize              int
+	MaxReceiveBufferPerConnection int
+	MaxReceiveBufferPerStream     int
+	PermitProhibitedCipherSuites  bool
+	IdleTimeout                   time.Duration
+	CountError                    func(errType string)
 }
 
 // ServerTransportOption modifies the ServerTransportOptions.
@@ -94,6 +109,20 @@ func WithIdleTimeout(timeout time.Duration) ServerTransportOption {
 func WithKeepAlivePeriod(d time.Duration) ServerTransportOption {
 	return func(options *ServerTransportOptions) {
 		options.KeepAlivePeriod = d
+	}
+}
+
+// WithEnableH2C returns a ServerTransportOption which enables H2C.
+func WithEnableH2C(enable bool) ServerTransportOption {
+	return func(options *ServerTransportOptions) {
+		options.EnableH2C = enable
+	}
+}
+
+// WithHTTP2Config returns a ServerTransportOption which sets HTTP/2 config.
+func WithHTTP2Config(config *HTTP2Config) ServerTransportOption {
+	return func(options *ServerTransportOptions) {
+		options.HTTP2Config = config
 	}
 }
 

--- a/transport/server_transport_test.go
+++ b/transport/server_transport_test.go
@@ -455,6 +455,23 @@ func TestWithKeepAlivePeriod(t *testing.T) {
 	assert.Equal(t, time.Minute, opts.KeepAlivePeriod)
 }
 
+func TestWithHTTP2Config(t *testing.T) {
+	config := &transport.HTTP2Config{MaxConcurrentStreams: 1}
+	opt := transport.WithHTTP2Config(config)
+	assert.NotNil(t, opt)
+	opts := &transport.ServerTransportOptions{}
+	opt(opts)
+	assert.Equal(t, config, opts.HTTP2Config)
+}
+
+func TestWithEnableH2C(t *testing.T) {
+	opt := transport.WithEnableH2C(true)
+	assert.NotNil(t, opt)
+	opts := &transport.ServerTransportOptions{}
+	opt(opts)
+	assert.True(t, opts.EnableH2C)
+}
+
 func TestWithServeTLS(t *testing.T) {
 	opt := transport.WithServeTLS("certfile", "keyfile", "")
 	assert.NotNil(t, opt)
@@ -462,6 +479,10 @@ func TestWithServeTLS(t *testing.T) {
 	opt(opts)
 	assert.Equal(t, "certfile", opts.TLSCertFile)
 	assert.Equal(t, "keyfile", opts.TLSKeyFile)
+
+	opt = transport.WithServeCertProvider("provider")
+	opt(opts)
+	assert.Equal(t, "provider", opts.TLSCertProvider)
 }
 
 // TestWithServeAsync tests setting server async.

--- a/transport/tnet/client_transport.go
+++ b/transport/tnet/client_transport.go
@@ -137,7 +137,13 @@ func Dial(opts *connpool.DialOptions) (net.Conn, error) {
 	if opts.TLSServerName == "" {
 		opts.TLSServerName = opts.Address
 	}
-	tlsConf, err := intertls.GetClientConfig(opts.TLSServerName, opts.CACertFile, opts.TLSCertFile, opts.TLSKeyFile)
+	tlsConf, err := intertls.GetClientConfig(
+		opts.TLSServerName,
+		opts.CACertFile,
+		opts.TLSCertFile,
+		opts.TLSKeyFile,
+		opts.TLSCertProvider,
+	)
 	if err != nil {
 		return nil, errs.WrapFrameError(err, errs.RetClientDecodeFail, "client dial tnet tls fail")
 	}

--- a/transport/tnet/client_transport_tcp.go
+++ b/transport/tnet/client_transport_tcp.go
@@ -75,14 +75,15 @@ func dialTCP(ctx context.Context, opts *transport.RoundTripOptions) (net.Conn, e
 			timeout = opts.DialTimeout
 		}
 		conn, err = Dial(&connpool.DialOptions{
-			Network:       opts.Network,
-			Address:       opts.Address,
-			LocalAddr:     opts.LocalAddr,
-			Timeout:       timeout,
-			CACertFile:    opts.CACertFile,
-			TLSCertFile:   opts.TLSCertFile,
-			TLSKeyFile:    opts.TLSKeyFile,
-			TLSServerName: opts.TLSServerName,
+			Network:         opts.Network,
+			Address:         opts.Address,
+			LocalAddr:       opts.LocalAddr,
+			Timeout:         timeout,
+			CACertFile:      opts.CACertFile,
+			TLSCertFile:     opts.TLSCertFile,
+			TLSKeyFile:      opts.TLSKeyFile,
+			TLSCertProvider: opts.TLSCertProvider,
+			TLSServerName:   opts.TLSServerName,
 		})
 		if err != nil {
 			return nil, errs.WrapFrameError(err, errs.RetClientConnectFail, "tcp client transport dial")
@@ -101,6 +102,7 @@ func dialTCP(ctx context.Context, opts *transport.RoundTripOptions) (net.Conn, e
 	getOpts.WithContext(ctx)
 	getOpts.WithFramerBuilder(opts.FramerBuilder)
 	getOpts.WithDialTLS(opts.TLSCertFile, opts.TLSKeyFile, opts.CACertFile, opts.TLSServerName)
+	getOpts.WithCertProvider(opts.TLSCertProvider)
 	getOpts.WithLocalAddr(opts.LocalAddr)
 	getOpts.WithDialTimeout(opts.DialTimeout)
 	getOpts.WithProtocol(opts.Protocol)
@@ -183,6 +185,7 @@ func (c *clientTransport) multiplex(ctx context.Context, req []byte, opts *trans
 	}
 	getOpts.WithFrameParser(fp)
 	getOpts.WithDialTLS(opts.TLSCertFile, opts.TLSKeyFile, opts.CACertFile, opts.TLSServerName)
+	getOpts.WithCertProvider(opts.TLSCertProvider)
 	getOpts.WithLocalAddr(opts.LocalAddr)
 	conn, err := opts.Multiplexed.GetMuxConn(ctx, opts.Network, opts.Address, getOpts)
 	if err != nil {

--- a/transport/tnet/multiplex/multiplex.go
+++ b/transport/tnet/multiplex/multiplex.go
@@ -193,13 +193,14 @@ func (p *pool) getHost(network string, address string, opts multiplexed.GetOptio
 		address:  address,
 		hostName: hostName,
 		dialOpts: dialOption{
-			fp:            opts.FP,
-			localAddr:     opts.LocalAddr,
-			caCertFile:    opts.CACertFile,
-			tlsCertFile:   opts.TLSCertFile,
-			tlsKeyFile:    opts.TLSKeyFile,
-			tlsServerName: opts.TLSServerName,
-			dialTimeout:   p.dialTimeout,
+			fp:              opts.FP,
+			localAddr:       opts.LocalAddr,
+			caCertFile:      opts.CACertFile,
+			tlsCertFile:     opts.TLSCertFile,
+			tlsKeyFile:      opts.TLSKeyFile,
+			tlsCertProvider: opts.TLSCertProvider,
+			tlsServerName:   opts.TLSServerName,
+			dialTimeout:     p.dialTimeout,
 		},
 		dialFunc:                     p.dialFunc,
 		maxConcurrentVirConnsPerConn: p.maxConcurrentVirConnsPerConn,
@@ -233,13 +234,14 @@ func (p *pool) metrics() {
 }
 
 type dialOption struct {
-	fp            multiplexed.FrameParser
-	localAddr     string
-	dialTimeout   time.Duration
-	caCertFile    string
-	tlsCertFile   string
-	tlsKeyFile    string
-	tlsServerName string
+	fp              multiplexed.FrameParser
+	localAddr       string
+	dialTimeout     time.Duration
+	caCertFile      string
+	tlsCertFile     string
+	tlsKeyFile      string
+	tlsCertProvider string
+	tlsServerName   string
 }
 
 // host manages all connections to the same network and address.
@@ -259,14 +261,15 @@ type host struct {
 func (h *host) singleflightDial() <-chan singleflight.Result {
 	ch := h.sfg.DoChan(h.hostName, func() (connection interface{}, err error) {
 		rawConn, err := h.dialFunc(&connpool.DialOptions{
-			Network:       h.network,
-			Address:       h.address,
-			Timeout:       h.dialOpts.dialTimeout,
-			LocalAddr:     h.dialOpts.localAddr,
-			CACertFile:    h.dialOpts.caCertFile,
-			TLSCertFile:   h.dialOpts.tlsCertFile,
-			TLSKeyFile:    h.dialOpts.tlsKeyFile,
-			TLSServerName: h.dialOpts.tlsServerName,
+			Network:         h.network,
+			Address:         h.address,
+			Timeout:         h.dialOpts.dialTimeout,
+			LocalAddr:       h.dialOpts.localAddr,
+			CACertFile:      h.dialOpts.caCertFile,
+			TLSCertFile:     h.dialOpts.tlsCertFile,
+			TLSKeyFile:      h.dialOpts.tlsKeyFile,
+			TLSCertProvider: h.dialOpts.tlsCertProvider,
+			TLSServerName:   h.dialOpts.tlsServerName,
 		})
 		if err != nil {
 			return nil, err

--- a/transport/tnet/server_transport_tcp.go
+++ b/transport/tnet/server_transport_tcp.go
@@ -191,7 +191,7 @@ func (s *serverTransport) startTLSService(
 	pool *ants.PoolWithFunc,
 	opts *transport.ListenServeOptions,
 ) error {
-	conf, err := intertls.GetServerConfig(opts.CACertFile, opts.TLSCertFile, opts.TLSKeyFile)
+	conf, err := intertls.GetServerConfig(opts.CACertFile, opts.TLSCertFile, opts.TLSKeyFile, opts.TLSCertProvider)
 	if err != nil {
 		return fmt.Errorf("get tls config fail: %w", err)
 	}

--- a/trpc.go
+++ b/trpc.go
@@ -169,6 +169,9 @@ func newServiceWithConfig(cfg *Config, serviceCfg *ServiceConfig, opt ...server.
 		server.WithMaxRoutines(serviceCfg.MaxRoutines),
 		server.WithWritev(*serviceCfg.Writev),
 	}
+	if serviceCfg.TLSCertProvider != "" {
+		opts = append(opts, server.WithCertProvider(serviceCfg.TLSCertProvider))
+	}
 	for i := range filters {
 		opts = append(opts, server.WithNamedFilter(filterNames[i], filters[i]))
 	}


### PR DESCRIPTION
## Summary
- sync stream close metadata propagation and stream selectNode-in-filter support
- add server ServiceName and propagate the interface update to admin/server mocks
- add custom TLS certificate provider support across HTTP, TCP, multiplexed, and tnet transports
- add configurable HTTP/2 server options for HTTP and REST transports

## Tests
- go test ./...
- git diff --check
- internal/local path leak scan on changed areas

## Notes
- router trie is intentionally left for a separate PR because the public REST router path-template behavior needs dedicated parity validation
