### PR TITLE
codec: support lz4 compression

### DIFF
--- a/codec/compress.go
+++ b/codec/compress.go
@@ -31,6 +31,8 @@ const (
 	CompressTypeZlib
 	CompressTypeStreamSnappy
 	CompressTypeBlockSnappy
+	CompressTypeStreamLZ4
+	CompressTypeBlockLZ4
 )
 
 var compressors = make(map[int]Compressor)

--- a/codec/compress_lz4.go
+++ b/codec/compress_lz4.go
@@ -1,0 +1,185 @@
+//
+//
+// Tencent is pleased to support the open source community by making tRPC available.
+//
+// Copyright (C) 2023 Tencent.
+// All rights reserved.
+//
+// If you have downloaded a copy of the tRPC source code from Tencent,
+// please note that tRPC source code is licensed under the  Apache 2.0 License,
+// A copy of the Apache 2.0 License is included in this file.
+//
+//
+
+package codec
+
+import (
+	"bytes"
+	"io"
+	"sync"
+
+	"github.com/pierrec/lz4/v4"
+)
+
+func init() {
+	RegisterCompressor(CompressTypeStreamLZ4, NewLZ4StreamCompressor())
+	RegisterCompressor(CompressTypeBlockLZ4, NewLZ4BlockCompressor())
+}
+
+// LZ4StreamCompressor is lz4 compressor using stream lz4 format.
+//
+// There are actually two LZ4 formats: block and stream. They are related,
+// but different: trying to decompress block-compressed data as a LZ4 stream
+// will fail, and vice versa.
+type LZ4StreamCompressor struct {
+	writerPool *sync.Pool
+	readerPool *sync.Pool
+}
+
+// NewLZ4StreamCompressor returns a stream format lz4 compressor instance.
+func NewLZ4StreamCompressor() *LZ4StreamCompressor {
+	s := &LZ4StreamCompressor{}
+	s.writerPool = &sync.Pool{
+		New: func() interface{} {
+			return lz4.NewWriter(&bytes.Buffer{})
+		},
+	}
+	s.readerPool = &sync.Pool{
+		New: func() interface{} {
+			return lz4.NewReader(&bytes.Buffer{})
+		},
+	}
+	return s
+}
+
+// Compress returns binary data compressed by lz4 stream format.
+func (c *LZ4StreamCompressor) Compress(in []byte) ([]byte, error) {
+	if len(in) == 0 {
+		return in, nil
+	}
+
+	buf := &bytes.Buffer{}
+	writer := c.getLZ4Writer(buf)
+	defer func() {
+		if c.writerPool != nil {
+			c.writerPool.Put(writer)
+		}
+	}()
+
+	if _, err := writer.Write(in); err != nil {
+		_ = writer.Close()
+		return nil, err
+	}
+	if err := writer.Close(); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+// Decompress returns binary data decompressed by lz4 stream format.
+func (c *LZ4StreamCompressor) Decompress(in []byte) ([]byte, error) {
+	if len(in) == 0 {
+		return in, nil
+	}
+
+	inReader := bytes.NewReader(in)
+	reader := c.getLZ4Reader(inReader)
+	defer func() {
+		if c.readerPool != nil {
+			c.readerPool.Put(reader)
+		}
+	}()
+
+	out, err := io.ReadAll(reader)
+	if err != nil {
+		return nil, err
+	}
+	return out, err
+}
+
+// LZ4BlockCompressor is lz4 compressor using lz4 block format.
+type LZ4BlockCompressor struct {
+	compressorPool *sync.Pool
+}
+
+// NewLZ4BlockCompressor returns a block format lz4 compressor instance.
+func NewLZ4BlockCompressor() *LZ4BlockCompressor {
+	return &LZ4BlockCompressor{
+		compressorPool: &sync.Pool{
+			New: func() interface{} {
+				return &lz4.Compressor{}
+			},
+		},
+	}
+}
+
+// Compress returns binary data compressed by lz4 block formats.
+func (c *LZ4BlockCompressor) Compress(in []byte) ([]byte, error) {
+	if len(in) == 0 {
+		return in, nil
+	}
+	cc := c.getLZ4Compressor()
+	defer func() {
+		if c.compressorPool != nil {
+			c.compressorPool.Put(cc)
+		}
+	}()
+	out := make([]byte, lz4.CompressBlockBound(len(in)))
+	n, err := cc.CompressBlock(in, out)
+	if err != nil {
+		return nil, err
+	}
+	return out[:n], nil
+}
+
+// Decompress returns binary data decompressed by lz4 block formats.
+func (c *LZ4BlockCompressor) Decompress(in []byte) ([]byte, error) {
+	if len(in) == 0 {
+		return in, nil
+	}
+	const somePossibleExpansionFactor = 10
+	out := make([]byte, somePossibleExpansionFactor*len(in))
+	n, err := lz4.UncompressBlock(in, out)
+	if err != nil {
+		return nil, err
+	}
+	return out[:n], nil
+}
+
+func (c *LZ4BlockCompressor) getLZ4Compressor() *lz4.Compressor {
+	if c.compressorPool == nil {
+		return &lz4.Compressor{}
+	}
+
+	compressor, ok := c.compressorPool.Get().(*lz4.Compressor)
+	if !ok || compressor == nil {
+		return &lz4.Compressor{}
+	}
+	return compressor
+}
+
+func (c *LZ4StreamCompressor) getLZ4Writer(buf *bytes.Buffer) *lz4.Writer {
+	if c.writerPool == nil {
+		return lz4.NewWriter(buf)
+	}
+
+	writer, ok := c.writerPool.Get().(*lz4.Writer)
+	if !ok || writer == nil {
+		return lz4.NewWriter(buf)
+	}
+	writer.Reset(buf)
+	return writer
+}
+
+func (c *LZ4StreamCompressor) getLZ4Reader(inReader *bytes.Reader) *lz4.Reader {
+	if c.readerPool == nil {
+		return lz4.NewReader(inReader)
+	}
+
+	reader, ok := c.readerPool.Get().(*lz4.Reader)
+	if !ok || reader == nil {
+		return lz4.NewReader(inReader)
+	}
+	reader.Reset(inReader)
+	return reader
+}

--- a/codec/compress_lz4_test.go
+++ b/codec/compress_lz4_test.go
@@ -1,0 +1,68 @@
+//
+//
+// Tencent is pleased to support the open source community by making tRPC available.
+//
+// Copyright (C) 2023 Tencent.
+// All rights reserved.
+//
+// If you have downloaded a copy of the tRPC source code from Tencent,
+// please note that tRPC source code is licensed under the  Apache 2.0 License,
+// A copy of the Apache 2.0 License is included in this file.
+//
+//
+
+package codec_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"trpc.group/trpc-go/trpc-go/codec"
+)
+
+func TestLZ4Compression(t *testing.T) {
+	cases := [][]byte{
+		[]byte("hello"),
+		[]byte(nil),
+	}
+	compressors := []codec.Compressor{
+		codec.NewLZ4BlockCompressor(),
+		codec.NewLZ4StreamCompressor(),
+		&codec.LZ4BlockCompressor{},
+		&codec.LZ4StreamCompressor{},
+	}
+	for _, compressor := range compressors {
+		for _, c := range cases {
+			bs, err := compressor.Compress(c)
+			require.NoError(t, err)
+			hh, err := compressor.Decompress(bs)
+			require.NoError(t, err)
+			require.Equal(t, c, hh)
+		}
+	}
+}
+
+func TestLZ4CompressorsAreRegistered(t *testing.T) {
+	require.NotNil(t, codec.GetCompressor(codec.CompressTypeStreamLZ4))
+	require.NotNil(t, codec.GetCompressor(codec.CompressTypeBlockLZ4))
+
+	in := []byte("hello")
+	for _, compressType := range []int{codec.CompressTypeStreamLZ4, codec.CompressTypeBlockLZ4} {
+		bs, err := codec.Compress(compressType, in)
+		require.NoError(t, err)
+		out, err := codec.Decompress(compressType, bs)
+		require.NoError(t, err)
+		require.Equal(t, in, out)
+	}
+}
+
+func TestLZ4DecompressInvalidInput(t *testing.T) {
+	invalid := []byte("invalid")
+
+	_, err := codec.NewLZ4StreamCompressor().Decompress(invalid)
+	require.Error(t, err)
+
+	_, err = codec.NewLZ4BlockCompressor().Decompress(invalid)
+	require.Error(t, err)
+}

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/lestrrat-go/strftime v1.0.6
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/panjf2000/ants/v2 v2.4.6
+	github.com/pierrec/lz4/v4 v4.1.21
 	github.com/spaolacci/murmur3 v1.1.0
 	github.com/spf13/cast v1.3.1
 	github.com/stretchr/testify v1.8.0

--- a/go.sum
+++ b/go.sum
@@ -54,6 +54,8 @@ github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9G
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/panjf2000/ants/v2 v2.4.6 h1:drmj9mcygn2gawZ155dRbo+NfXEfAssjZNU1qoIb4gQ=
 github.com/panjf2000/ants/v2 v2.4.6/go.mod h1:f6F0NZVFsGCp5A7QW/Zj/m92atWwOkY0OIhFxRNFr4A=
+github.com/pierrec/lz4/v4 v4.1.21 h1:yOVMLb6qSIDP67pl/5F7RepeKYu/VmTyEXvuMI5d9mQ=
+github.com/pierrec/lz4/v4 v4.1.21/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFuRQyBid4=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=


### PR DESCRIPTION
## Summary

- add built-in LZ4 stream and block compressors
- register LZ4 compression type constants
- add tests for round trips, registration, and invalid input

## Tests

- go test ./codec
- go test ./...