### PR TITLE
router: implement trie-based router

### DIFF
--- a/restful/pattern.go
+++ b/restful/pattern.go
@@ -18,6 +18,15 @@ import "trpc.group/trpc-go/trpc-go/internal/httprule"
 // Pattern makes *httprule.PathTemplate accessible.
 type Pattern struct {
 	*httprule.PathTemplate
+	rawURLPath string
+}
+
+// RawURLPath returns the raw URL path defined in the proto file.
+func (p *Pattern) RawURLPath() string {
+	if p == nil {
+		return ""
+	}
+	return p.rawURLPath
 }
 
 // Parse parses the url path into a *Pattern. It should only be used by trpc-cmdline.
@@ -26,7 +35,7 @@ func Parse(urlPath string) (*Pattern, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &Pattern{tpl}, nil
+	return &Pattern{PathTemplate: tpl, rawURLPath: urlPath}, nil
 }
 
 // Enforce ensures the url path is legal (will panic if illegal) and parses it into a *Pattern.

--- a/restful/router.go
+++ b/restful/router.go
@@ -35,6 +35,7 @@ import (
 type Router struct {
 	opts        *Options
 	transcoders map[string][]*transcoder
+	routerTrie  *RouterTrie
 }
 
 // NewRouter creates a Router.
@@ -55,6 +56,7 @@ func NewRouter(opts ...Option) *Router {
 	return &Router{
 		opts:        &o,
 		transcoders: make(map[string][]*transcoder),
+		routerTrie:  newRouterTrie(),
 	}
 }
 
@@ -124,7 +126,10 @@ func (r *Router) AddImplBinding(binding *Binding, serviceImpl interface{}) error
 	}
 	// add transcoder
 	r.transcoders[binding.HTTPMethod] = append(r.transcoders[binding.HTTPMethod], tr)
-	return nil
+	if r.routerTrie == nil {
+		r.routerTrie = newRouterTrie()
+	}
+	return r.routerTrie.insert(binding.HTTPMethod, tr)
 }
 
 func (r *Router) newTranscoder(binding *Binding, serviceImpl interface{}) (*transcoder, error) {
@@ -292,14 +297,30 @@ func putBackCtxMessage(ctx context.Context) {
 // TODO: better routing handling.
 func (r *Router) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	ctx := ctxForCompatibility(req.Context(), w, req)
-	for _, tr := range r.transcoders[req.Method] {
-		fieldValues, err := tr.pat.Match(req.URL.Path)
-		if err == nil {
-			r.handle(ctx, w, req, tr, fieldValues)
-			return
-		}
+	tr, fieldValues := r.findTranscoder(req.Method, req.URL.Path)
+	if tr != nil {
+		r.handle(ctx, w, req, tr, fieldValues)
+		return
 	}
 	r.opts.ErrorHandler(ctx, w, req, errs.New(errs.RetServerNoFunc, "failed to match any pattern"))
+}
+
+func (r *Router) findTranscoder(method, path string) (*transcoder, map[string]string) {
+	if r.routerTrie != nil {
+		if tr := r.routerTrie.search(method, path); tr != nil {
+			fieldValues, err := tr.pat.Match(path)
+			if err == nil {
+				return tr, fieldValues
+			}
+		}
+	}
+	for _, tr := range r.transcoders[method] {
+		fieldValues, err := tr.pat.Match(path)
+		if err == nil {
+			return tr, fieldValues
+		}
+	}
+	return nil, nil
 }
 
 func (r *Router) handle(

--- a/restful/router_trie.go
+++ b/restful/router_trie.go
@@ -1,0 +1,270 @@
+//
+//
+// Tencent is pleased to support the open source community by making tRPC available.
+//
+// Copyright (C) 2023 Tencent.
+// All rights reserved.
+//
+// If you have downloaded a copy of the tRPC source code from Tencent,
+// please note that tRPC source code is licensed under the  Apache 2.0 License,
+// A copy of the Apache 2.0 License is included in this file.
+//
+//
+
+package restful
+
+import "strings"
+
+// trieNode represents a node in the prefix tree.
+type trieNode struct {
+	indices  string
+	paths    []string
+	children []*trieNode
+
+	paramChild    *trieNode
+	wildcardChild *trieNode
+
+	transcoder *transcoder
+	isEnd      bool
+}
+
+func newTrieNode() *trieNode {
+	return &trieNode{
+		indices:  "",
+		children: make([]*trieNode, 0),
+	}
+}
+
+type methodTree struct {
+	method string
+	root   *trieNode
+}
+
+// RouterTrie is a routing trie organized by HTTP method.
+type RouterTrie struct {
+	trees []*methodTree
+}
+
+func newRouterTrie() *RouterTrie {
+	return &RouterTrie{
+		trees: make([]*methodTree, 0),
+	}
+}
+
+func (rt *RouterTrie) insert(method string, tr *transcoder) error {
+	root := rt.getOrCreateRoot(method)
+
+	segments := parsePattern(tr.pat.RawURLPath())
+	current := root
+	for i, seg := range segments {
+		isLast := i == len(segments)-1
+
+		switch seg.typ {
+		case segmentTypeStatic:
+			child := current.getChild(seg.value)
+			if child == nil {
+				child = current.addChild(seg.value)
+			}
+			current = child
+		case segmentTypeParam:
+			if current.paramChild == nil {
+				current.paramChild = newTrieNode()
+			}
+			current = current.paramChild
+		case segmentTypeWildcard:
+			if current.wildcardChild == nil {
+				current.wildcardChild = newTrieNode()
+			}
+			current = current.wildcardChild
+		}
+
+		if isLast {
+			current.isEnd = true
+			current.transcoder = tr
+		}
+	}
+
+	return nil
+}
+
+func (rt *RouterTrie) getOrCreateRoot(method string) *trieNode {
+	for _, tree := range rt.trees {
+		if tree.method == method {
+			return tree.root
+		}
+	}
+
+	tree := &methodTree{
+		method: method,
+		root:   newTrieNode(),
+	}
+	rt.trees = append(rt.trees, tree)
+	return tree.root
+}
+
+func (node *trieNode) getChild(path string) *trieNode {
+	if path == "" {
+		return nil
+	}
+
+	firstChar := path[0]
+	for i := 0; i < len(node.indices); i++ {
+		if node.indices[i] == firstChar && node.paths[i] == path {
+			return node.children[i]
+		}
+	}
+	return nil
+}
+
+func (node *trieNode) addChild(path string) *trieNode {
+	child := newTrieNode()
+	node.indices += string(path[0])
+	node.paths = append(node.paths, path)
+	node.children = append(node.children, child)
+	return child
+}
+
+type segmentType int
+
+const (
+	segmentTypeStatic segmentType = iota
+	segmentTypeParam
+	segmentTypeWildcard
+)
+
+type pathSegment struct {
+	typ   segmentType
+	value string
+}
+
+func parsePattern(pattern string) []pathSegment {
+	pattern = strings.TrimPrefix(pattern, "/")
+	if pattern == "" {
+		return nil
+	}
+
+	parts := splitPatternParts(pattern)
+	segments := make([]pathSegment, 0, len(parts))
+	for _, part := range parts {
+		if part == "" {
+			continue
+		}
+		if part == "**" || part == "*" {
+			segments = append(segments, pathSegment{typ: segmentTypeWildcard, value: part})
+			continue
+		}
+		if strings.HasPrefix(part, "{") && strings.HasSuffix(part, "}") {
+			paramContent := part[1 : len(part)-1]
+			if paramContent == "" {
+				continue
+			}
+			if eqIdx := strings.Index(paramContent, "="); eqIdx > 0 {
+				prefixPattern := paramContent[eqIdx+1:]
+				for _, prefixPart := range strings.Split(prefixPattern, "/") {
+					if prefixPart == "" {
+						continue
+					}
+					if prefixPart == "**" || prefixPart == "*" {
+						segments = append(segments, pathSegment{typ: segmentTypeWildcard, value: prefixPart})
+					} else {
+						segments = append(segments, pathSegment{typ: segmentTypeStatic, value: prefixPart})
+					}
+				}
+			} else {
+				segments = append(segments, pathSegment{typ: segmentTypeParam, value: paramContent})
+			}
+			continue
+		}
+		segments = append(segments, pathSegment{typ: segmentTypeStatic, value: part})
+	}
+
+	return segments
+}
+
+func splitPatternParts(pattern string) []string {
+	var parts []string
+	var current strings.Builder
+	braceDepth := 0
+
+	for i := 0; i < len(pattern); i++ {
+		c := pattern[i]
+		switch c {
+		case '{':
+			braceDepth++
+			current.WriteByte(c)
+		case '}':
+			braceDepth--
+			current.WriteByte(c)
+		case '/':
+			if braceDepth == 0 {
+				if current.Len() > 0 {
+					parts = append(parts, current.String())
+					current.Reset()
+				}
+			} else {
+				current.WriteByte(c)
+			}
+		default:
+			current.WriteByte(c)
+		}
+	}
+
+	if current.Len() > 0 {
+		parts = append(parts, current.String())
+	}
+	return parts
+}
+
+func (rt *RouterTrie) search(method, path string) *transcoder {
+	root := rt.getRoot(method)
+	if root == nil {
+		return nil
+	}
+
+	path = strings.TrimPrefix(path, "/")
+	segments := strings.Split(path, "/")
+	if len(segments) == 1 && segments[0] == "" {
+		segments = nil
+	}
+
+	return rt.dfs(root, segments, 0)
+}
+
+func (rt *RouterTrie) getRoot(method string) *trieNode {
+	for _, tree := range rt.trees {
+		if tree.method == method {
+			return tree.root
+		}
+	}
+	return nil
+}
+
+func (rt *RouterTrie) dfs(node *trieNode, segments []string, index int) *transcoder {
+	if index == len(segments) {
+		if node.isEnd && node.transcoder != nil {
+			return node.transcoder
+		}
+		return nil
+	}
+
+	currentSegment := segments[index]
+	if child := node.getChild(currentSegment); child != nil {
+		if tr := rt.dfs(child, segments, index+1); tr != nil {
+			return tr
+		}
+	}
+
+	if node.paramChild != nil {
+		if tr := rt.dfs(node.paramChild, segments, index+1); tr != nil {
+			return tr
+		}
+	}
+
+	if node.wildcardChild != nil {
+		if tr := rt.dfs(node.wildcardChild, segments, len(segments)); tr != nil {
+			return tr
+		}
+	}
+
+	return nil
+}

--- a/restful/router_trie_test.go
+++ b/restful/router_trie_test.go
@@ -1,0 +1,229 @@
+//
+//
+// Tencent is pleased to support the open source community by making tRPC available.
+//
+// Copyright (C) 2023 Tencent.
+// All rights reserved.
+//
+// If you have downloaded a copy of the tRPC source code from Tencent,
+// please note that tRPC source code is licensed under the  Apache 2.0 License,
+// A copy of the Apache 2.0 License is included in this file.
+//
+//
+
+package restful
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func newTestTranscoder(t *testing.T, name, pattern string) *transcoder {
+	t.Helper()
+	pat, err := Parse(pattern)
+	require.NoError(t, err)
+	return &transcoder{name: name, pat: pat}
+}
+
+func TestPatternRawURLPath(t *testing.T) {
+	pat, err := Parse("/api/users/{id}")
+	require.NoError(t, err)
+	require.Equal(t, "/api/users/{id}", pat.RawURLPath())
+
+	var nilPattern *Pattern
+	require.Empty(t, nilPattern.RawURLPath())
+}
+
+func TestParsePattern(t *testing.T) {
+	tests := []struct {
+		name    string
+		pattern string
+		want    []pathSegment
+	}{
+		{
+			name:    "static",
+			pattern: "/api/users",
+			want: []pathSegment{
+				{typ: segmentTypeStatic, value: "api"},
+				{typ: segmentTypeStatic, value: "users"},
+			},
+		},
+		{
+			name:    "parameter",
+			pattern: "/api/users/{id}",
+			want: []pathSegment{
+				{typ: segmentTypeStatic, value: "api"},
+				{typ: segmentTypeStatic, value: "users"},
+				{typ: segmentTypeParam, value: "id"},
+			},
+		},
+		{
+			name:    "wildcard",
+			pattern: "/api/**",
+			want: []pathSegment{
+				{typ: segmentTypeStatic, value: "api"},
+				{typ: segmentTypeWildcard, value: "**"},
+			},
+		},
+		{
+			name:    "constrained parameter keeps slash-delimited constraint",
+			pattern: "/proxy/{path=trpc/go/**}",
+			want: []pathSegment{
+				{typ: segmentTypeStatic, value: "proxy"},
+				{typ: segmentTypeStatic, value: "trpc"},
+				{typ: segmentTypeStatic, value: "go"},
+				{typ: segmentTypeWildcard, value: "**"},
+			},
+		},
+		{
+			name:    "skips empty parts",
+			pattern: "/api//users/",
+			want: []pathSegment{
+				{typ: segmentTypeStatic, value: "api"},
+				{typ: segmentTypeStatic, value: "users"},
+			},
+		},
+		{
+			name:    "root",
+			pattern: "/",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, parsePattern(tt.pattern))
+		})
+	}
+}
+
+func TestRouterTrieSearch(t *testing.T) {
+	trie := newRouterTrie()
+	routes := []struct {
+		method  string
+		pattern string
+		name    string
+	}{
+		{method: "GET", pattern: "/api/users", name: "ListUsers"},
+		{method: "POST", pattern: "/api/users", name: "CreateUser"},
+		{method: "GET", pattern: "/api/users/{id}", name: "GetUser"},
+		{method: "GET", pattern: "/api/users/{id}/posts/{post_id}", name: "GetPost"},
+		{method: "GET", pattern: "/api/**", name: "WildcardAPI"},
+		{method: "GET", pattern: "/proxy/{path=trpc/go/**}", name: "Proxy"},
+	}
+	for _, route := range routes {
+		require.NoError(t, trie.insert(route.method, newTestTranscoder(t, route.name, route.pattern)))
+	}
+
+	tests := []struct {
+		method string
+		path   string
+		want   string
+	}{
+		{method: "GET", path: "/api/users", want: "ListUsers"},
+		{method: "POST", path: "/api/users", want: "CreateUser"},
+		{method: "GET", path: "/api/users/123", want: "GetUser"},
+		{method: "GET", path: "/api/users/123/posts/456", want: "GetPost"},
+		{method: "GET", path: "/api/anything/else", want: "WildcardAPI"},
+		{method: "GET", path: "/proxy/trpc/go/pkg/restful", want: "Proxy"},
+		{method: "PATCH", path: "/api/users", want: ""},
+		{method: "GET", path: "/api/users/123/missing/456", want: "WildcardAPI"},
+	}
+
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("%s %s", tt.method, tt.path), func(t *testing.T) {
+			got := trie.search(tt.method, tt.path)
+			if tt.want == "" {
+				require.Nil(t, got)
+				return
+			}
+			require.NotNil(t, got)
+			require.Equal(t, tt.want, got.name)
+		})
+	}
+}
+
+func TestRouterTriePriority(t *testing.T) {
+	trie := newRouterTrie()
+	routes := []struct {
+		pattern string
+		name    string
+	}{
+		{pattern: "/api/**", name: "Wildcard"},
+		{pattern: "/api/users/{id}", name: "Param"},
+		{pattern: "/api/users/me", name: "Static"},
+	}
+	for _, route := range routes {
+		require.NoError(t, trie.insert("GET", newTestTranscoder(t, route.name, route.pattern)))
+	}
+
+	tests := []struct {
+		path string
+		want string
+	}{
+		{path: "/api/users/me", want: "Static"},
+		{path: "/api/users/123", want: "Param"},
+		{path: "/api/other/path", want: "Wildcard"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.path, func(t *testing.T) {
+			got := trie.search("GET", tt.path)
+			require.NotNil(t, got)
+			require.Equal(t, tt.want, got.name)
+		})
+	}
+}
+
+func TestRouterFindTranscoderUsesTriePriority(t *testing.T) {
+	router := NewRouter()
+	for _, route := range []struct {
+		pattern string
+		name    string
+	}{
+		{pattern: "/api/users/{id}", name: "Param"},
+		{pattern: "/api/users/me", name: "Static"},
+	} {
+		require.NoError(t, router.AddImplBinding(&Binding{
+			Name:       route.name,
+			Input:      func() ProtoMessage { return nil },
+			Filter:     func(interface{}, context.Context, interface{}) (interface{}, error) { return nil, nil },
+			HTTPMethod: "GET",
+			Pattern:    Enforce(route.pattern),
+		}, nil))
+	}
+
+	tr, fields := router.findTranscoder("GET", "/api/users/me")
+	require.NotNil(t, tr)
+	require.Equal(t, "Static", tr.name)
+	require.Empty(t, fields)
+}
+
+func TestRouterTrieFallsBackForPatternMismatch(t *testing.T) {
+	router := NewRouter()
+	require.NoError(t, router.AddImplBinding(&Binding{
+		Name:       "OneSegmentWildcard",
+		Input:      func() ProtoMessage { return nil },
+		Filter:     func(interface{}, context.Context, interface{}) (interface{}, error) { return nil, nil },
+		HTTPMethod: "GET",
+		Pattern:    Enforce("/files/*"),
+	}, nil))
+
+	tr, fields := router.findTranscoder("GET", "/files/a/b")
+	require.Nil(t, tr)
+	require.Nil(t, fields)
+}
+
+func TestRouterTrieNodeOperations(t *testing.T) {
+	node := newTrieNode()
+	require.Nil(t, node.getChild(""))
+
+	api := node.addChild("api")
+	require.Equal(t, api, node.getChild("api"))
+	require.Nil(t, node.getChild("app"))
+
+	users := node.addChild("users")
+	require.Equal(t, users, node.getChild("users"))
+	require.Equal(t, "au", node.indices)
+}


### PR DESCRIPTION
## Summary

- add a trie-backed RESTful router organized by HTTP method
- prefer static routes over parameter routes, and parameter routes over wildcard routes
- keep linear matching as a compatibility fallback for complex patterns that cannot be resolved by the trie candidate
- retain the raw RESTful path pattern so trie construction can preserve constrained path segments

## Tests

- go test ./restful
- go test ./restful -coverprofile=/tmp/trpc-go-router-cover.out
- go test ./...