### PR TITLE
all: sync selected config http and restful fixes

### DIFF
--- a/config/trpc_config.go
+++ b/config/trpc_config.go
@@ -329,6 +329,11 @@ func (c *TrpcConfig) get() *entity {
 
 // init return config entity error when entity is empty and load run loads config once
 func (c *TrpcConfig) init() error {
+	if !c.watch {
+		c.mutex.Lock()
+		defer c.mutex.Unlock()
+		return c.readAndSet()
+	}
 	c.mutex.RLock()
 	if c.value != nil {
 		c.mutex.RUnlock()
@@ -342,12 +347,18 @@ func (c *TrpcConfig) init() error {
 		return nil
 	}
 
+	return c.readAndSet()
+}
+
+// readAndSet reads data from provider and sets it to the config
+func (c *TrpcConfig) readAndSet() error {
 	data, err := c.p.Read(c.path)
 	if err != nil {
 		return fmt.Errorf("trpc/config failed to load error: %w config id: %s", err, c.id)
 	}
 	return c.set(data)
 }
+
 func (c *TrpcConfig) doWatch(data []byte) error {
 	c.mutex.Lock()
 	defer c.mutex.Unlock()

--- a/http/transport.go
+++ b/http/transport.go
@@ -118,8 +118,6 @@ func (t *ServerTransport) listenAndServeHTTP(ctx context.Context, opts *transpor
 		// Generates new empty general message structure data and save it to ctx.
 		ctx, msg := codec.WithNewMessage(ctx)
 		defer codec.PutBackMessage(msg)
-		// The old request must be replaced to ensure that the context is embedded.
-		h.Request = r.WithContext(ctx)
 		defer func() {
 			// Fix issues/778
 			if r.MultipartForm == nil {
@@ -132,6 +130,9 @@ func (t *ServerTransport) listenAndServeHTTP(ctx context.Context, opts *transpor
 		span.SetAttribute(rpcz.HTTPAttributeURL, r.URL)
 		span.SetAttribute(rpcz.HTTPAttributeRequestContentLength, r.ContentLength)
 
+		// The old request must be replaced to ensure that the latest context is embedded
+		// into the http.Request passed to RspHandler/ErrHandler.
+		h.Request = r.WithContext(ctx)
 		// Records LocalAddr and RemoteAddr to Context.
 		localAddr, ok := h.Request.Context().Value(stdhttp.LocalAddrContextKey).(net.Addr)
 		if ok {

--- a/http/transport_test.go
+++ b/http/transport_test.go
@@ -59,6 +59,7 @@ import (
 	thttp "trpc.group/trpc-go/trpc-go/http"
 	"trpc.group/trpc-go/trpc-go/log"
 	"trpc.group/trpc-go/trpc-go/naming/registry"
+	"trpc.group/trpc-go/trpc-go/rpcz"
 	"trpc.group/trpc-go/trpc-go/server"
 	"trpc.group/trpc-go/trpc-go/testdata/restful/helloworld"
 	"trpc.group/trpc-go/trpc-go/transport"
@@ -1555,4 +1556,114 @@ func (t *mockTransport) RoundTrip(ctx context.Context, req []byte, opts ...trans
 	}
 	msg.WithRemoteAddr(raddr)
 	return []byte("mock transport"), nil
+}
+
+func TestHTTPRspHandlerContextIsLatest(t *testing.T) {
+	oldRPCZ := rpcz.GlobalRPCZ
+	rpcz.GlobalRPCZ = rpcz.NewRPCZ(&rpcz.Config{Fraction: 1.0, Capacity: 16})
+	defer func() {
+		rpcz.GlobalRPCZ = oldRPCZ
+	}()
+
+	oldRsp := thttp.DefaultServerCodec.RspHandler
+	defer func() { thttp.DefaultServerCodec.RspHandler = oldRsp }()
+
+	spanNameCh := make(chan string, 1)
+	thttp.DefaultServerCodec.RspHandler = func(w http.ResponseWriter, r *http.Request, body []byte) error {
+		spanNameCh <- rpcz.SpanFromContext(r.Context()).Name()
+		if len(body) > 0 {
+			_, _ = w.Write(body)
+		}
+		return nil
+	}
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer ln.Close()
+
+	svc := server.New(
+		server.WithListener(ln),
+		server.WithServiceName("trpc.http.ctx.latest.rsp"),
+		server.WithProtocol("http"),
+	)
+
+	oldMethods := thttp.ServiceDesc.Methods
+	defer func() { thttp.ServiceDesc.Methods = oldMethods }()
+
+	thttp.HandleFunc("/ctx", func(w http.ResponseWriter, r *http.Request) error {
+		_, _ = w.Write([]byte("OK"))
+		return nil
+	})
+	thttp.RegisterDefaultService(svc)
+
+	s := &server.Server{}
+	s.AddService("trpc.http.ctx.latest.rsp", svc)
+
+	go func() { _ = s.Serve() }()
+	defer func() { _ = s.Close(nil) }()
+	time.Sleep(100 * time.Millisecond)
+
+	resp, err := http.Get("http://" + ln.Addr().String() + "/ctx")
+	require.NoError(t, err)
+	_ = resp.Body.Close()
+
+	select {
+	case name := <-spanNameCh:
+		require.Equal(t, "http-server", name, "RspHandler should observe span injected after request was bound")
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for RspHandler span name")
+	}
+}
+
+func TestHTTPErrHandlerContextIsLatest(t *testing.T) {
+	oldRPCZ := rpcz.GlobalRPCZ
+	rpcz.GlobalRPCZ = rpcz.NewRPCZ(&rpcz.Config{Fraction: 1.0, Capacity: 16})
+	defer func() {
+		rpcz.GlobalRPCZ = oldRPCZ
+	}()
+
+	oldErr := thttp.DefaultServerCodec.ErrHandler
+	defer func() { thttp.DefaultServerCodec.ErrHandler = oldErr }()
+
+	spanNameCh := make(chan string, 1)
+	thttp.DefaultServerCodec.ErrHandler = func(w http.ResponseWriter, r *http.Request, e *errs.Error) {
+		spanNameCh <- rpcz.SpanFromContext(r.Context()).Name()
+		// mimic default behavior: status will be set by framework based on error code.
+	}
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer ln.Close()
+
+	svc := server.New(
+		server.WithListener(ln),
+		server.WithServiceName("trpc.http.ctx.latest.err"),
+		server.WithProtocol("http"),
+	)
+
+	oldMethods := thttp.ServiceDesc.Methods
+	defer func() { thttp.ServiceDesc.Methods = oldMethods }()
+
+	thttp.HandleFunc("/err", func(w http.ResponseWriter, r *http.Request) error {
+		return errs.New(errs.RetServerSystemErr, "boom")
+	})
+	thttp.RegisterDefaultService(svc)
+
+	s := &server.Server{}
+	s.AddService("trpc.http.ctx.latest.err", svc)
+
+	go func() { _ = s.Serve() }()
+	defer func() { _ = s.Close(nil) }()
+	time.Sleep(100 * time.Millisecond)
+
+	resp, err := http.Get("http://" + ln.Addr().String() + "/err")
+	require.NoError(t, err)
+	_ = resp.Body.Close()
+
+	select {
+	case name := <-spanNameCh:
+		require.Equal(t, "http-server", name, "ErrHandler should observe span injected after request was bound")
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for ErrHandler span name")
+	}
 }

--- a/restful/router.go
+++ b/restful/router.go
@@ -288,7 +288,10 @@ var DefaultResponseHandler = func(
 // putBackCtxMessage calls codec.PutBackMessage to put a codec.Msg back to pool,
 // if the codec.Msg has been put into ctx.
 func putBackCtxMessage(ctx context.Context) {
-	if msg, ok := ctx.Value(codec.ContextKeyMessage).(codec.Msg); ok {
+	if ctx == nil {
+		return
+	}
+	if msg, ok := ctx.Value(codec.ContextKeyMessage).(codec.Msg); ok && msg != nil {
 		codec.PutBackMessage(msg)
 	}
 }
@@ -332,6 +335,7 @@ func (r *Router) handle(
 ) {
 	modifiedCtx, err := r.opts.HeaderMatcher(ctx, w, req, r.opts.ServiceName, tr.name)
 	if err != nil {
+		putBackCtxMessage(modifiedCtx)
 		r.opts.ErrorHandler(ctx, w, req, errs.New(errs.RetServerDecodeFail, err.Error()))
 		return
 	}

--- a/restful/router_test.go
+++ b/restful/router_test.go
@@ -23,12 +23,14 @@ import (
 	"net/http"
 	"os"
 	"strconv"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
 
 	trpc "trpc.group/trpc-go/trpc-go"
+	"trpc.group/trpc-go/trpc-go/codec"
 	"trpc.group/trpc-go/trpc-go/errs"
 	"trpc.group/trpc-go/trpc-go/filter"
 	thttp "trpc.group/trpc-go/trpc-go/http"
@@ -310,4 +312,114 @@ type greeterAlwaysTimeout struct{}
 func (*greeterAlwaysTimeout) SayHello(ctx context.Context, req *helloworld.HelloRequest) (*helloworld.HelloReply, error) {
 	<-ctx.Done()
 	return nil, errs.NewFrameError(errs.RetServerTimeout, "ctx timeout")
+}
+
+// TestMsgLifecycle_ConcurrentScenarios stress tests all error paths under concurrent load.
+// Run with: go test -race -run TestMsgLifecycle_ConcurrentScenarios
+func TestMsgLifecycle_ConcurrentScenarios(t *testing.T) {
+	tests := []struct {
+		name        string
+		setupServer func(*testing.T, net.Listener) server.Service
+	}{
+		{
+			name: "handler_errors",
+			setupServer: func(t *testing.T, l net.Listener) server.Service {
+				s := server.New(
+					server.WithListener(l),
+					server.WithServiceName(t.Name()),
+					server.WithProtocol("restful"),
+				)
+				RegisterGreeterService(s, &errorReturningGreeter{err: errors.New("error"), errorRate: 0.3})
+				return s
+			},
+		},
+		{
+			name: "header_matcher_errors",
+			setupServer: func(t *testing.T, l net.Listener) server.Service {
+				var count int32
+				s := server.New(
+					server.WithListener(l),
+					server.WithServiceName(t.Name()),
+					server.WithProtocol("restful"),
+					server.WithRESTOptions(
+						restful.WithHeaderMatcher(func(ctx context.Context, w http.ResponseWriter, r *http.Request, serviceName, methodName string) (context.Context, error) {
+							ctx, msg := codec.WithNewMessage(ctx)
+							msg.WithServerRPCName(methodName)
+							msg.WithCalleeServiceName(serviceName)
+							c := atomic.AddInt32(&count, 1)
+							if c%2 == 0 {
+								return ctx, errors.New("header error")
+							}
+							return ctx, nil
+						}),
+					),
+				)
+				RegisterGreeterService(s, &greeter{})
+				return s
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			l := mustListen(t)
+			defer l.Close()
+
+			s := tt.setupServer(t, l)
+			mustStartServer(t, s)
+			defer s.Close(nil)
+
+			// Concurrent requests
+			const numRequests = 100
+			done := make(chan bool, numRequests)
+			for i := 0; i < numRequests; i++ {
+				go func() {
+					rsp, err := http.Get(fmt.Sprintf("http://%s/v2/bar/world", l.Addr().String()))
+					if err == nil {
+						rsp.Body.Close()
+					}
+					done <- true
+				}()
+			}
+
+			// Wait for all requests
+			for i := 0; i < numRequests; i++ {
+				<-done
+			}
+		})
+	}
+}
+
+type errorReturningGreeter struct {
+	err       error
+	errorRate float64
+	counter   int32
+}
+
+func (s *errorReturningGreeter) SayHello(ctx context.Context, req *helloworld.HelloRequest) (*helloworld.HelloReply, error) {
+	if s.errorRate > 0 {
+		count := atomic.AddInt32(&s.counter, 1)
+		if float64(count%10) < s.errorRate*10 {
+			return nil, s.err
+		}
+	} else if s.err != nil {
+		return nil, s.err
+	}
+	return &helloworld.HelloReply{Message: req.Name}, nil
+}
+
+func mustListen(t *testing.T) net.Listener {
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	require.Nil(t, err)
+	return l
+}
+
+func mustStartServer(t *testing.T, s server.Service) {
+	errCh := make(chan error)
+	go func() { errCh <- s.Serve() }()
+	select {
+	case err := <-errCh:
+		require.FailNow(t, "serve failed", err)
+	case <-time.After(100 * time.Millisecond):
+	}
 }


### PR DESCRIPTION
## Summary

- Sync public-compatible parts of internal !3040, !3048, and !3064.
- Reload unwatched config from the provider during initialization instead of reusing cached watcher state.
- Bind the HTTP request to the latest context after rpcz span injection so response and error handlers observe the updated context.
- Make RESTful message putback nil-safe and release messages returned by failing header matchers.

## Compatibility

- No go.mod changes.
- The SSE memory leak fix from !3102 is deferred because the public branch does not have the internal sse_event parser yet.
- The !3117 return-error aggregation is deferred because the public watcher interface does not return errors; the existing public code already passes doWatch errors to notify.

## Tests

- go test ./config ./http ./restful
- go test ./...
