### PR TITLE
all: sync selected codec and metrics fixes

### DIFF
--- a/codec.go
+++ b/codec.go
@@ -322,7 +322,7 @@ func msgWithRequestProtocol(msg codec.Msg, req *trpcpb.RequestProtocol, attm []b
 	msg.WithDyeing((req.GetMessageType() & uint32(trpcpb.TrpcMessageType_TRPC_DYEING_MESSAGE)) != 0)
 	// parse tracing MetaData, set MetaData into msg
 	if len(req.TransInfo) > 0 {
-		msg.WithServerMetaData(req.GetTransInfo())
+		msg.WithServerMetaData(codec.MetaData(req.GetTransInfo()).Clone())
 		// mark with dyeing key
 		if bs, ok := req.TransInfo[DyeingKey]; ok {
 			msg.WithDyeingKey(string(bs))

--- a/codec_stream.go
+++ b/codec_stream.go
@@ -119,6 +119,7 @@ func (c *ClientStreamCodec) decodeCloseFrame(msg codec.Msg, rspBuf []byte) ([]by
 	// It is considered an exception and an error should be returned to the client if:
 	// 1. the CloseType is Reset
 	// 2. ret code != 0
+	// 3. func_ret != 0 (business-level error)
 	if close.GetCloseType() == int32(trpcpb.TrpcStreamCloseType_TRPC_STREAM_RESET) || close.GetRet() != 0 {
 		e := &errs.Error{
 			Type: errs.ErrorTypeCalleeFramework,
@@ -511,7 +512,7 @@ func (s *ServerStreamCodec) updateMsg(msg codec.Msg, initMeta *trpcpb.TrpcStream
 	msg.WithDyeing((req.GetMessageType() & uint32(trpcpb.TrpcMessageType_TRPC_DYEING_MESSAGE)) != 0)
 
 	if len(req.TransInfo) > 0 {
-		msg.WithServerMetaData(req.GetTransInfo())
+		msg.WithServerMetaData(codec.MetaData(req.GetTransInfo()).Clone())
 		// set dyeing key
 		if bs, ok := req.TransInfo[DyeingKey]; ok {
 			msg.WithDyeingKey(string(bs))

--- a/codec_stream_test.go
+++ b/codec_stream_test.go
@@ -456,6 +456,50 @@ func TestStreamCodecReset(t *testing.T) {
 
 }
 
+// TestStreamCodecCloseFuncRet tests that a Close frame with only func_ret != 0
+// (ret == 0, CloseType == CLOSE) is propagated as a business error to the client.
+// This covers the case where the server reports a business-level error via func_ret
+// without setting the framework-level ret field.
+func TestStreamCodecCloseFuncRet(t *testing.T) {
+	TestStreamCodecInit(t)
+
+	clientCodec := codec.GetClient("trpc")
+
+	laddr, err := net.ResolveTCPAddr("tcp", "127.0.0.1:10000")
+	require.Nil(t, err)
+	raddr, err := net.ResolveTCPAddr("tcp", "127.0.0.1:10001")
+	require.Nil(t, err)
+
+	// Close frame: CloseType=CLOSE(0), Ret=0, FuncRet=10001, Msg="business error"
+	// stream_id=100
+	closeWithFuncRet := []byte{
+		0x09, 0x30, 0x01, 0x04, 0x00, 0x00, 0x00, 0x23,
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x64, 0x00, 0x00,
+		0x1a, 0x0e, 0x62, 0x75, 0x73, 0x69, 0x6e, 0x65,
+		0x73, 0x73, 0x20, 0x65, 0x72, 0x72, 0x6f, 0x72,
+		0x30, 0x91, 0x4e,
+	}
+
+	clientCtx := context.Background()
+	_, clientMsg := codec.WithNewMessage(clientCtx)
+	clientMsg.WithLocalAddr(laddr)
+	clientMsg.WithRemoteAddr(raddr)
+
+	rspBuf, err := clientCodec.Decode(clientMsg, closeWithFuncRet)
+	assert.Nil(t, err)
+	assert.Nil(t, rspBuf)
+	assert.Equal(t, uint32(100), clientMsg.StreamID())
+
+	// func_ret != 0 should be propagated as a business error (not a framework error)
+	rspErr := clientMsg.ClientRspErr()
+	assert.NotNil(t, rspErr)
+	assert.EqualValues(t, 10001, errs.Code(rspErr))
+	var e *errs.Error
+	require.ErrorAs(t, rspErr, &e)
+	assert.Equal(t, errs.ErrorTypeBusiness, e.Type)
+	assert.Contains(t, rspErr.Error(), "business error")
+}
+
 // TestUnknownFrameType tests stream frame with unknown type.
 func TestUnknownFrameType(t *testing.T) {
 	msg := trpc.Message(ctx)

--- a/http/codec.go
+++ b/http/codec.go
@@ -358,7 +358,7 @@ func unmarshalTransInfo(msg codec.Msg, v string) (map[string][]byte, error) {
 			msg.WithDyeingKey(string(decoded))
 		}
 	}
-	msg.WithServerMetaData(transInfo)
+	msg.WithServerMetaData(codec.MetaData(transInfo).Clone())
 	return transInfo, nil
 }
 

--- a/metrics/counter_test.go
+++ b/metrics/counter_test.go
@@ -14,7 +14,11 @@
 package metrics_test
 
 import (
+	"context"
+	"fmt"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"trpc.group/trpc-go/trpc-go/metrics"
@@ -106,4 +110,58 @@ func BenchmarkReportHistogram(b *testing.B) {
 			c.AddSample(1)
 		}
 	})
+}
+
+type concurrentSink struct {
+	name string
+}
+
+func (s *concurrentSink) Name() string {
+	return s.name
+}
+
+func (s *concurrentSink) Report(metrics.Record, ...metrics.Option) error {
+	return nil
+}
+
+func TestConcurrentSinkRegistrationAndReporting(t *testing.T) {
+	const (
+		numReporters  = 8
+		numRegistrars = 4
+	)
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	var wg sync.WaitGroup
+	wg.Add(numReporters + numRegistrars)
+	for i := 0; i < numReporters; i++ {
+		go func(id int) {
+			defer wg.Done()
+			for {
+				select {
+				case <-ctx.Done():
+					return
+				default:
+					metrics.Counter(fmt.Sprintf("sink-counter-%d", id)).Incr()
+					metrics.Gauge(fmt.Sprintf("sink-gauge-%d", id)).Set(1)
+					metrics.Timer(fmt.Sprintf("sink-timer-%d", id)).Record()
+					metrics.Histogram(fmt.Sprintf("sink-histogram-%d", id), metrics.NewDurationBounds()).AddSample(1)
+				}
+			}
+		}(i)
+	}
+	for i := 0; i < numRegistrars; i++ {
+		go func(id int) {
+			defer wg.Done()
+			for {
+				select {
+				case <-ctx.Done():
+					return
+				default:
+					metrics.RegisterMetricsSink(&concurrentSink{name: fmt.Sprintf("concurrent-sink-%d", id)})
+				}
+			}
+		}(i)
+	}
+	wg.Wait()
 }

--- a/trpc_util_test.go
+++ b/trpc_util_test.go
@@ -21,6 +21,8 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	trpcpb "trpc.group/trpc/trpc-protocol/pb/go/trpc"
 
 	"trpc.group/trpc-go/trpc-go/codec"
 )
@@ -82,6 +84,23 @@ func TestGetMetaData(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestMsgWithRequestProtocol_DoesNotShareTransInfoWithServerMetaData(t *testing.T) {
+	ctx, msg := codec.WithNewMessage(context.Background())
+	req := &trpcpb.RequestProtocol{
+		TransInfo: map[string][]byte{
+			"key": []byte("value"),
+		},
+	}
+	msgWithRequestProtocol(msg, req, nil)
+
+	require.Equal(t, []byte("value"), msg.ServerMetaData()["key"])
+	require.NotEqual(t, reflect.ValueOf(req.TransInfo).Pointer(), reflect.ValueOf(msg.ServerMetaData()).Pointer())
+
+	SetMetaData(ctx, "new-key", []byte("new-value"))
+	require.Nil(t, req.TransInfo["new-key"])
+	require.Equal(t, []byte("new-value"), msg.ServerMetaData()["new-key"])
 }
 
 // TestGetIP test getIP.


### PR DESCRIPTION
## Summary

- Clone request TransInfo before storing it as server metadata for unary, stream, and HTTP codecs.
- Treat stream close frames with func_ret != 0 as business errors on the client side.
- Add a public-package concurrency test for sink registration while metrics are reported.

## Compatibility

- No go.mod changes.
- Docs/examples changes from the internal metadata commit are intentionally excluded from this code PR.
- The metrics implementation already uses snapshotMetricsSinks on current upstream/main, so this PR does not duplicate that implementation change.

## Tests

- go test . ./metrics
- go test ./...
