### PR TITLE
all: sync selected stability fixes

### DIFF
--- a/config/trpc_config.go
+++ b/config/trpc_config.go
@@ -364,6 +364,9 @@ func (c *TrpcConfig) set(data []byte) error {
 	if err != nil {
 		return fmt.Errorf("trpc/config: failed to parse:%w, id:%s", err, c.id)
 	}
+	if v, ok := e.data.(map[interface{}]interface{}); ok {
+		e.data = cast.ToStringMap(v)
+	}
 	c.value = e
 	return nil
 }

--- a/config/trpc_config_test.go
+++ b/config/trpc_config_test.go
@@ -143,6 +143,21 @@ func TestYamlCodec_Unmarshal(t *testing.T) {
 	})
 }
 
+func TestTrpcConfigStringifiesTopLevelYAMLKeys(t *testing.T) {
+	provider := NewEnvProvider(t.Name(), []byte(`
+1:
+  name: numeric
+true:
+  name: boolean
+`))
+	RegisterProvider(provider)
+
+	cfg, err := DefaultConfigLoader.Load(t.Name(), WithProvider(provider.Name()), WithCodec("yaml"))
+	require.NoError(t, err)
+	require.Equal(t, "numeric", cfg.GetString("1.name", ""))
+	require.Equal(t, "boolean", cfg.GetString("true.name", ""))
+}
+
 func TestEnvExpanded(t *testing.T) {
 	RegisterProvider(NewEnvProvider(t.Name(), []byte(`
 password: ${pwd}

--- a/server/service.go
+++ b/server/service.go
@@ -150,6 +150,10 @@ var New = func(opts ...Option) Service {
 func (s *service) Serve() error {
 	pid := os.Getpid()
 
+	if len(s.handlers) == 0 && len(s.streamHandlers) == 0 {
+		log.Warnf("process:%d service:%s no handlers registered", pid, s.opts.ServiceName)
+	}
+
 	// make sure ListenAndServe succeeds before Naming Service Registry.
 	if err := s.opts.Transport.ListenAndServe(s.ctx, s.opts.ServeOptions...); err != nil {
 		log.Errorf("process:%d service:%s ListenAndServe fail:%v", pid, s.opts.ServiceName, err)
@@ -422,6 +426,10 @@ func (s *service) filterFunc(
 		err = codec.Unmarshal(serializationType, reqBodyBuf, reqBody)
 		end.End()
 		if err != nil {
+			log.TraceContextf(ctx,
+				"ServiceCodecUnmarshalFail: callerService:%s callerMethod:%s calleeService:%s calleeMethod:%s req:%+X",
+				msg.CallerService(), msg.CallerMethod(), msg.CalleeService(), msg.CalleeMethod(), reqBodyBuf,
+			)
 			report.ServiceCodecUnmarshalFail.Incr()
 			return nil, errs.NewFrameError(errs.RetServerDecodeFail, "service codec Unmarshal: "+err.Error())
 		}

--- a/transport/client_transport_tcp.go
+++ b/transport/client_transport_tcp.go
@@ -15,6 +15,7 @@ package transport
 
 import (
 	"context"
+	"errors"
 	"net"
 	"time"
 
@@ -247,11 +248,11 @@ func (c *clientTransport) multiplexed(ctx context.Context, req []byte, opts *Rou
 
 	buf, err := conn.Read()
 	if err != nil {
-		if err == context.Canceled {
+		if errors.Is(err, context.Canceled) {
 			return nil, errs.NewFrameError(errs.RetClientCanceled,
 				"tcp client multiplexed transport ReadFrame: "+err.Error())
 		}
-		if err == context.DeadlineExceeded {
+		if errors.Is(err, context.DeadlineExceeded) {
 			return nil, errs.NewFrameError(errs.RetClientTimeout,
 				"tcp client multiplexed transport ReadFrame: "+err.Error())
 		}

--- a/transport/tnet/client_transport_tcp.go
+++ b/transport/tnet/client_transport_tcp.go
@@ -206,11 +206,11 @@ func (c *clientTransport) multiplex(ctx context.Context, req []byte, opts *trans
 
 	buf, err := conn.Read()
 	if err != nil {
-		if err == context.Canceled {
+		if errors.Is(err, context.Canceled) {
 			return nil, errs.NewFrameError(errs.RetClientCanceled,
 				"tcp tnet multiplexed ReadFrame: "+err.Error())
 		}
-		if err == context.DeadlineExceeded {
+		if errors.Is(err, context.DeadlineExceeded) {
 			return nil, errs.NewFrameError(errs.RetClientTimeout,
 				"tcp tnet multiplexed ReadFrame: "+err.Error())
 		}


### PR DESCRIPTION
## What changed

- Normalize top-level YAML maps with non-string keys so `TrpcConfig.Get` can resolve numeric and boolean YAML keys through string paths.
- Add a warning when a service starts without unary or stream handlers registered.
- Add trace context for service codec unmarshal failures.
- Recognize wrapped `context.Canceled` and `context.DeadlineExceeded` errors in TCP multiplexed reads for both standard and tnet transports.

## Compatibility

This PR keeps API compatibility. It does not add dependencies or change successful request behavior. The TCP multiplexed change only preserves existing error-code mapping when context errors are wrapped.

## Validation

- `go test ./config ./server ./transport ./transport/tnet`
- `go test ./...`
