### PR TITLE
log: add DisableTrace

### DIFF
--- a/log/log.go
+++ b/log/log.go
@@ -46,6 +46,11 @@ func EnableTrace() {
 	traceEnabled = true
 }
 
+// DisableTrace disables trace.
+func DisableTrace() {
+	traceEnabled = false
+}
+
 // SetLevel sets log level for different output which may be "0", "1" or "2".
 func SetLevel(output string, level Level) {
 	GetDefaultLogger().SetLevel(output, level)

--- a/log/log_test.go
+++ b/log/log_test.go
@@ -49,6 +49,24 @@ func TestLogXXX(t *testing.T) {
 	log.Fatal("xxx")
 }
 
+func TestDisableTrace(t *testing.T) {
+	old := log.GetDefaultLogger()
+	defer log.SetLogger(old)
+	defer log.DisableTrace()
+
+	out := &bytes.Buffer{}
+	log.SetLogger(log.NewZapBufLogger(out, 0))
+
+	log.EnableTrace()
+	log.Trace("visible trace")
+	require.Contains(t, out.String(), "visible trace")
+
+	out.Reset()
+	log.DisableTrace()
+	log.Trace("hidden trace")
+	require.NotContains(t, out.String(), "hidden trace")
+}
+
 func TestLoggerNil(t *testing.T) {
 	ctx := context.Background()
 	ctx, msg := codec.WithNewMessage(ctx)


### PR DESCRIPTION
## What changed

Add `log.DisableTrace()` as the counterpart to `log.EnableTrace()`.

## Compatibility

This is an additive API. It does not change the default trace setting and does not add dependencies.

## Validation

- `go test ./log`
- `go test ./...`
