### PR TITLE
all: sync stability and http features

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -442,6 +442,7 @@ func selectNode(ctx context.Context, msg codec.Msg, opts *Options) (*registry.No
 	opts.SelectOptions = append(opts.SelectOptions, selector.WithContext(ctx))
 	node, err := getNode(opts)
 	if err != nil {
+		ensureMsgCalleeInfo(msg, opts)
 		report.SelectNodeFail.Incr()
 		return nil, err
 	}
@@ -473,6 +474,19 @@ func selectNode(ctx context.Context, msg codec.Msg, opts *Options) (*registry.No
 	}
 
 	return node, nil
+}
+
+func ensureMsgCalleeInfo(msg codec.Msg, opts *Options) {
+	if opts == nil {
+		return
+	}
+	o := selector.Options{}
+	for _, opt := range opts.SelectOptions {
+		opt(&o)
+	}
+	if o.DestinationSetName != "" {
+		msg.WithCalleeSetName(o.DestinationSetName)
+	}
 }
 
 func getNode(opts *Options) (*registry.Node, error) {

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -436,6 +436,33 @@ func TestSelectorRemoteAddrUseUserProvidedParser(t *testing.T) {
 	require.Equal(t, t.Name(), addr.String())
 }
 
+func TestSelectorFailKeepsCalleeSetName(t *testing.T) {
+	const (
+		selectorName = "selector_fail_set"
+		protocolName = "fake_selector_fail_set"
+		calleeSet    = "test_set"
+	)
+	selector.Register(selectorName, &fSelector{
+		selectNode: func(string, ...selector.Option) (*registry.Node, error) {
+			return nil, errors.New("select fail")
+		},
+		report: func(*registry.Node, time.Duration, error) error { return nil },
+	})
+	codec.Register(protocolName, nil, &fakeCodec{})
+
+	ctx, msg := codec.WithNewMessage(context.Background())
+	defer codec.PutBackMessage(msg)
+	err := client.New().Invoke(ctx, &codec.Body{Data: []byte("test")}, &codec.Body{},
+		client.WithTarget(selectorName+"://127.0.0.1:8080"),
+		client.WithProtocol(protocolName),
+		client.WithCurrentSerializationType(codec.SerializationTypeNoop),
+		client.WithCalleeSetName(calleeSet),
+	)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "select fail")
+	require.Equal(t, calleeSet, msg.CalleeSetName())
+}
+
 type multiplexedTransport struct {
 	require func(context.Context, []byte, ...transport.RoundTripOption)
 	fakeTransport

--- a/client/options.go
+++ b/client/options.go
@@ -77,10 +77,11 @@ type Options struct {
 	RspHead interface{} // Allow custom rsp head.
 	Node    *onceNode   // For getting node info.
 
-	MaxWindowSize uint32            // Max size of stream receiver's window.
-	SControl      SendControl       // Sender's flow control.
-	RControl      RecvControl       // Receiver's flow control.
-	StreamFilters StreamFilterChain // Stream filter chain.
+	DisabledFlowControl bool
+	MaxWindowSize       uint32            // Max size of stream receiver's window.
+	SControl            SendControl       // Sender's flow control.
+	RControl            RecvControl       // Receiver's flow control.
+	StreamFilters       StreamFilterChain // Stream filter chain.
 
 	// EnableStreamSelectInFilter toggles selecting stream nodes inside the stream filter chain
 	// instead of during stream.Init. Disabled by default to preserve legacy behavior.
@@ -568,6 +569,13 @@ func WithStreamTransport(st transport.ClientStreamTransport) Option {
 func WithMaxWindowSize(s uint32) Option {
 	return func(o *Options) {
 		o.MaxWindowSize = s
+	}
+}
+
+// WithDisableStreamFlowControl disables flow control of streaming.
+func WithDisableStreamFlowControl() Option {
+	return func(o *Options) {
+		o.DisabledFlowControl = true
 	}
 }
 

--- a/client/options_test.go
+++ b/client/options_test.go
@@ -245,6 +245,10 @@ func TestOptions(t *testing.T) {
 	o(opts)
 	require.Equal(t, uint32(1024), opts.MaxWindowSize)
 
+	o = client.WithDisableStreamFlowControl()
+	o(opts)
+	require.True(t, opts.DisabledFlowControl)
+
 	o = client.WithMultiplexed(true)
 	o(opts)
 	require.Equal(t, true, opts.EnableMultiplexed)

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/panjf2000/ants/v2 v2.4.6
 	github.com/pierrec/lz4/v4 v4.1.21
+	github.com/r3labs/sse/v2 v2.10.0
 	github.com/spaolacci/murmur3 v1.1.0
 	github.com/spf13/cast v1.3.1
 	github.com/stretchr/testify v1.8.0
@@ -45,4 +46,5 @@ require (
 	github.com/valyala/bytebufferpool v1.0.0 // indirect
 	go.uber.org/multierr v1.6.0 // indirect
 	golang.org/x/text v0.13.0 // indirect
+	gopkg.in/cenkalti/backoff.v1 v1.1.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -60,6 +60,8 @@ github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/r3labs/sse/v2 v2.10.0 h1:hFEkLLFY4LDifoHdiCN/LlGBAdVJYsANaLqNYa1l/v0=
+github.com/r3labs/sse/v2 v2.10.0/go.mod h1:Igau6Whc+F17QUgML1fYe1VPZzTV6EMCnYktEmkNJ7I=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spaolacci/murmur3 v1.1.0 h1:7c1g84S4BPRrfL5Xrdp6fOJ206sU9y293DDHaoy0bLI=
@@ -71,6 +73,7 @@ github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSS
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
@@ -97,6 +100,7 @@ golang.org/x/mod v0.0.0-20190513183733-4bf6d317e70e/go.mod h1:mXi4GBBbnImb6dmsKG
 golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/net v0.0.0-20191116160921-f9c825593386/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20220906165146-f3363e06e74c/go.mod h1:YDH+HFinaLZZlnHAfSS6ZXJJ9M9t4Dl22yv3iI2vPwk=
 golang.org/x/net v0.17.0 h1:pVaXccu2ozPjCXewfr1S7xza/zcXTity9cCdXQYSjIM=
@@ -130,6 +134,8 @@ google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp0
 google.golang.org/protobuf v1.30.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
 google.golang.org/protobuf v1.33.0 h1:uNO2rsAINq/JlFpSdYEKIZ0uKD/R9cpdv0T+yoGwGmI=
 google.golang.org/protobuf v1.33.0/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHhKbcUYpos=
+gopkg.in/cenkalti/backoff.v1 v1.1.0 h1:Arh75ttbsvlpVA7WtVpH4u9h6Zl46xuptxqLxPiSo4Y=
+gopkg.in/cenkalti/backoff.v1 v1.1.0/go.mod h1:J6Vskwqd+OMVJl8C33mmtxTBs2gyzfv7UDAkHu8BrjI=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/http/codec.go
+++ b/http/codec.go
@@ -27,6 +27,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/r3labs/sse/v2"
 	trpcpb "trpc.group/trpc/trpc-protocol/pb/go/trpc"
 
 	"trpc.group/trpc-go/trpc-go/codec"
@@ -234,6 +235,28 @@ type ClientRspHeader struct {
 	// The default value is false.
 	ManualReadBody bool
 	Response       *http.Response
+
+	// ResponseHandler is invoked when SSECondition returns false or SSEHandler is not set.
+	// It only takes effect when ManualReadBody is false.
+	ResponseHandler RspHandler
+
+	// SSECondition determines whether the response should be handled as server-sent events.
+	// If SSECondition is nil, the default condition always returns true.
+	SSECondition func(*http.Response) bool
+
+	// SSEHandler handles server-sent event callbacks.
+	// It only takes effect when ManualReadBody is false.
+	SSEHandler SSEHandler
+}
+
+// RspHandler handles common HTTP responses.
+type RspHandler interface {
+	Handle(*http.Response) error
+}
+
+// SSEHandler handles server-sent events.
+type SSEHandler interface {
+	Handle(*sse.Event) error
 }
 
 // ErrsToHTTPStatus maps from framework errs retcode to http status code.
@@ -289,7 +312,6 @@ func (sc *ServerCodec) setReqHeader(head *Header, msg codec.Msg) error {
 
 	trpcReq := &trpcpb.RequestProtocol{}
 	msg.WithServerReqHead(trpcReq)
-	msg.WithServerRspHead(trpcReq)
 
 	trpcReq.Func = []byte(msg.ServerRPCName())
 	trpcReq.ContentType = uint32(msg.SerializationType())
@@ -334,7 +356,20 @@ func (sc *ServerCodec) setReqHeader(head *Header, msg codec.Msg) error {
 		}
 		trpcReq.TransInfo = transInfo
 	}
+	msg.WithServerRspHead(newResponseProtocol(trpcReq))
 	return nil
+}
+
+func newResponseProtocol(req *trpcpb.RequestProtocol) *trpcpb.ResponseProtocol {
+	return &trpcpb.ResponseProtocol{
+		Version:         req.GetVersion(),
+		CallType:        req.GetCallType(),
+		MessageType:     req.GetMessageType(),
+		RequestId:       req.GetRequestId(),
+		ContentType:     req.GetContentType(),
+		ContentEncoding: req.GetContentEncoding(),
+		TransInfo:       req.GetTransInfo(),
+	}
 }
 
 func unmarshalTransInfo(msg codec.Msg, v string) (map[string][]byte, error) {
@@ -582,17 +617,74 @@ func (c *ClientCodec) Encode(msg codec.Msg, reqBody []byte) ([]byte, error) {
 		}
 	}
 
+	var rspHeader *ClientRspHeader
 	if msg.ClientRspHead() != nil { // User himself has set http client rsp header.
-		_, ok := msg.ClientRspHead().(*ClientRspHeader)
+		header, ok := msg.ClientRspHead().(*ClientRspHeader)
 		if !ok {
 			return nil, errors.New("http header must be type of *http.ClientRspHeader")
 		}
+		rspHeader = header
 	} else {
-		msg.WithClientRspHead(&ClientRspHeader{})
+		rspHeader = &ClientRspHeader{}
+		msg.WithClientRspHead(rspHeader)
 	}
 
+	tryFillSSEHeaders(reqHeader, rspHeader)
 	c.updateMsg(msg)
 	return reqBody, nil
+}
+
+func tryFillSSEHeaders(reqHeader *ClientReqHeader, rspHeader *ClientRspHeader) {
+	if rspHeader.SSEHandler == nil {
+		return
+	}
+	tryAddHeader(reqHeader, "Accept", "text/event-stream")
+	tryAddHeader(reqHeader, Connection, "keep-alive")
+	tryAddHeader(reqHeader, "Cache-Control", "no-cache")
+}
+
+func tryAddHeader(reqHeader *ClientReqHeader, key, value string) {
+	if reqHeader.Header.Get(key) != "" {
+		return
+	}
+	reqHeader.AddHeader(key, value)
+}
+
+var defaultSSECondition = func(*http.Response) bool {
+	return true
+}
+
+func handleResponseBody(rspHeader *ClientRspHeader, msg codec.Msg) ([]byte, error) {
+	rsp := rspHeader.Response
+	if rsp.Body == nil || rspHeader.ManualReadBody {
+		return nil, nil
+	}
+	defer rsp.Body.Close()
+
+	if rspHeader.SSECondition == nil {
+		rspHeader.SSECondition = defaultSSECondition
+	}
+	if rspHeader.SSECondition(rsp) && rspHeader.SSEHandler != nil {
+		if err := handleSSE(rsp.Body, rspHeader.SSEHandler, msg); err != nil {
+			return nil, fmt.Errorf("handle sse error: %w", err)
+		}
+		return nil, nil
+	}
+	if rspHeader.ResponseHandler != nil {
+		if err := rspHeader.ResponseHandler.Handle(rsp); err != nil {
+			return nil, fmt.Errorf("handle response error: %w", err)
+		}
+		return nil, nil
+	}
+
+	body, err := io.ReadAll(rsp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("readall http body fail: %w", err)
+	}
+	// Reset body and allow multiple read.
+	rsp.Body.Close()
+	rsp.Body = io.NopCloser(bytes.NewReader(body))
+	return body, nil
 }
 
 // Decode parses metadata in http client's response.
@@ -607,14 +699,8 @@ func (c *ClientCodec) Decode(msg codec.Msg, _ []byte) ([]byte, error) {
 		err  error
 	)
 	rsp := rspHeader.Response
-	if rsp.Body != nil && !rspHeader.ManualReadBody {
-		defer rsp.Body.Close()
-		if body, err = io.ReadAll(rsp.Body); err != nil {
-			return nil, fmt.Errorf("readall http body fail: %w", err)
-		}
-		// Reset body and allow multiple read.
-		rsp.Body.Close()
-		rsp.Body = io.NopCloser(bytes.NewReader(body))
+	if body, err = handleResponseBody(rspHeader, msg); err != nil {
+		return nil, err
 	}
 
 	if val := rsp.Header.Get("Content-Encoding"); val != "" {

--- a/http/codec_test.go
+++ b/http/codec_test.go
@@ -245,6 +245,17 @@ func TestServerDecodeHTTPHeader(t *testing.T) {
 	require.Equal(t, "val1", string(req.GetTransInfo()["key1"]))
 	require.Equal(t, "val2", string(req.GetTransInfo()["key2"]))
 
+	rsp, ok := msg.ServerRspHead().(*trpcpb.ResponseProtocol)
+	require.True(t, ok)
+	require.NotNil(t, rsp, "failed to decode get trpc rsp head")
+	require.Equal(t, req.GetVersion(), rsp.GetVersion())
+	require.Equal(t, req.GetCallType(), rsp.GetCallType())
+	require.Equal(t, req.GetMessageType(), rsp.GetMessageType())
+	require.Equal(t, req.GetRequestId(), rsp.GetRequestId())
+	require.Equal(t, req.GetContentType(), rsp.GetContentType())
+	require.Equal(t, req.GetContentEncoding(), rsp.GetContentEncoding())
+	require.Equal(t, req.GetTransInfo(), rsp.GetTransInfo())
+
 	// JSON unmarshal failed.
 	r.Header.Set(thttp.TrpcTransInfo, `{"key1":"dmFsMQ==", "key2":"dmFsMg=="`)
 	w = &httptest.ResponseRecorder{}

--- a/http/restful_server_transport.go
+++ b/http/restful_server_transport.go
@@ -181,7 +181,11 @@ func (st *RESTServerTransport) serve(
 	// Get router.
 	router := restful.GetRouter(opts.ServiceName)
 	if router == nil {
-		return fmt.Errorf("service %s router not registered", opts.ServiceName)
+		if st.basedOnFastHTTP {
+			router = restful.NewRouter()
+		} else {
+			router = http.NewServeMux()
+		}
 	}
 
 	if st.basedOnFastHTTP { // Based on fasthttp.

--- a/http/restful_server_transport_test.go
+++ b/http/restful_server_transport_test.go
@@ -229,6 +229,28 @@ func TestReplaceRouter(t *testing.T) {
 	require.Nil(t, err)
 }
 
+func TestRESTfulListenAndServeEmptyRouter(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.Nil(t, err)
+	defer ln.Close()
+	st := thttp.NewRESTServerTransport(false, transport.WithReusePort(false))
+	require.Nil(t, st.ListenAndServe(context.Background(),
+		transport.WithListener(ln),
+		transport.WithServiceName(t.Name()),
+	))
+}
+
+func TestRESTfulListenAndServeEmptyRouterFastHTTP(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.Nil(t, err)
+	defer ln.Close()
+	st := thttp.NewRESTServerTransport(true, transport.WithReusePort(false))
+	require.Nil(t, st.ListenAndServe(context.Background(),
+		transport.WithListener(ln),
+		transport.WithServiceName(t.Name()),
+	))
+}
+
 var (
 	headerMatcherTransInfo, _ = json.Marshal(map[string]string{
 		"kfuin": base64.StdEncoding.EncodeToString([]byte("3009025887")),

--- a/http/serialization_get.go
+++ b/http/serialization_get.go
@@ -15,6 +15,7 @@ package http
 
 import (
 	"errors"
+	"net/url"
 
 	"trpc.group/trpc-go/trpc-go/codec"
 )
@@ -25,20 +26,36 @@ func init() {
 
 // NewGetSerialization initializes the get serialized object.
 func NewGetSerialization(tag string) codec.Serializer {
+	return NewGetSerializationWithCaseSensitive(tag, false)
+}
+
+// NewGetSerializationWithCaseSensitive initializes the get serialized object.
+// Register the returned serializer with codec.RegisterSerializer to use it.
+// By default, GET serialization is case-insensitive for backward compatibility.
+func NewGetSerializationWithCaseSensitive(tag string, caseSensitive bool) codec.Serializer {
 	formSerializer := NewFormSerialization(tag)
 	return &GetSerialization{
 		formSerializer: formSerializer.(*FormSerialization),
+		caseSensitive:  caseSensitive,
 	}
 }
 
 // GetSerialization packages kv structure of the http get request.
 type GetSerialization struct {
 	formSerializer *FormSerialization
+	caseSensitive  bool
 }
 
 // Unmarshal unpacks kv structure.
 func (s *GetSerialization) Unmarshal(in []byte, body interface{}) error {
-	return s.formSerializer.Unmarshal(in, body)
+	if s.caseSensitive {
+		return s.formSerializer.Unmarshal(in, body)
+	}
+	values, err := url.ParseQuery(string(in))
+	if err != nil {
+		return err
+	}
+	return unmarshalValues(s.formSerializer.tagname, values, body)
 }
 
 // Marshal packages kv structure.

--- a/http/serialization_get_test.go
+++ b/http/serialization_get_test.go
@@ -93,6 +93,7 @@ func TestGetSerializer(t *testing.T) {
 	}
 
 	for i, query := range expects {
+		query := query
 		buf, _ := s.Marshal(&query)
 		require.Equal(string(buf), expectedQueries[i], "x should be equal")
 	}

--- a/http/serialization_get_test.go
+++ b/http/serialization_get_test.go
@@ -141,3 +141,30 @@ func TestGetMarshal(t *testing.T) {
 	_, err := s.Marshal(require)
 	require.NotNil(err)
 }
+
+func TestGetSerializationCaseSensitive(t *testing.T) {
+	type helloReq struct {
+		Msg string `json:"msg,omitempty"`
+	}
+
+	old := codec.GetSerializer(codec.SerializationTypeGet)
+	defer codec.RegisterSerializer(codec.SerializationTypeGet, old)
+
+	s := codec.GetSerializer(codec.SerializationTypeGet)
+	for _, query := range []string{"msg=hello", "Msg=hello", "mSg=hello"} {
+		req := &helloReq{}
+		require.Nil(t, s.Unmarshal([]byte(query), req))
+		require.Equal(t, "hello", req.Msg)
+	}
+
+	codec.RegisterSerializer(codec.SerializationTypeGet, http.NewGetSerializationWithCaseSensitive("json", true))
+	s = codec.GetSerializer(codec.SerializationTypeGet)
+
+	req := &helloReq{}
+	require.Nil(t, s.Unmarshal([]byte("msg=hello"), req))
+	require.Equal(t, "hello", req.Msg)
+
+	req = &helloReq{}
+	require.Nil(t, s.Unmarshal([]byte("Msg=hello"), req))
+	require.Empty(t, req.Msg)
+}

--- a/http/sse_event.go
+++ b/http/sse_event.go
@@ -1,0 +1,115 @@
+//
+//
+// Tencent is pleased to support the open source community by making tRPC available.
+//
+// Copyright (C) 2023 Tencent.
+// All rights reserved.
+//
+// If you have downloaded a copy of the tRPC source code from Tencent,
+// please note that tRPC source code is licensed under the  Apache 2.0 License,
+// A copy of the Apache 2.0 License is included in this file.
+//
+//
+
+package http
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/r3labs/sse/v2"
+	trpc "trpc.group/trpc-go/trpc-go"
+	"trpc.group/trpc-go/trpc-go/codec"
+	"trpc.group/trpc-go/trpc-go/errs"
+)
+
+func handleSSE(body io.Reader, handle SSEHandler, msg codec.Msg) error {
+	reader := sse.NewEventStreamReader(body, trpc.DefaultMaxFrameSize)
+	for {
+		bs, err := reader.ReadEvent()
+		if err != nil {
+			if err == io.EOF {
+				return nil
+			}
+			return fmt.Errorf("sse reader read event error: %w", err)
+		}
+		event, err := processEvent(bs)
+		if err != nil {
+			return fmt.Errorf("parsing sse event error: %w", err)
+		}
+		if err := handle.Handle(event); err != nil {
+			var e *errs.Error
+			if errors.As(err, &e) && e.Type == errs.ErrorTypeBusiness {
+				msg.WithClientRspErr(err)
+				return nil
+			}
+			return fmt.Errorf("sse handler handle event error: %w", err)
+		}
+	}
+}
+
+var (
+	headerID      = []byte("id:")
+	headerData    = []byte("data:")
+	headerEvent   = []byte("event:")
+	headerRetry   = []byte("retry:")
+	headerComment = []byte(":")
+)
+
+func processEvent(msg []byte) (*sse.Event, error) {
+	if len(msg) == 0 {
+		return nil, errors.New("event message was empty")
+	}
+
+	var event sse.Event
+	for _, line := range bytes.FieldsFunc(msg, func(r rune) bool { return r == '\n' || r == '\r' }) {
+		switch {
+		case bytes.HasPrefix(line, headerID):
+			event.ID = trimHeader(len(headerID), line)
+		case bytes.HasPrefix(line, headerData):
+			event.Data = append(event.Data, append(trimHeader(len(headerData), line), byte('\n'))...)
+		case bytes.Equal(line, bytes.TrimSuffix(headerData, []byte(":"))):
+			event.Data = append(event.Data, byte('\n'))
+		case bytes.HasPrefix(line, headerEvent):
+			event.Event = trimHeader(len(headerEvent), line)
+		case bytes.HasPrefix(line, headerRetry):
+			event.Retry = trimHeader(len(headerRetry), line)
+		case bytes.HasPrefix(line, headerComment):
+			event.Comment = trimHeader(len(headerComment), line)
+		default:
+		}
+	}
+	event.Data = bytes.TrimSuffix(event.Data, []byte("\n"))
+	return &sse.Event{
+		ID:      safeCopy(event.ID),
+		Data:    safeCopy(event.Data),
+		Event:   safeCopy(event.Event),
+		Retry:   safeCopy(event.Retry),
+		Comment: safeCopy(event.Comment),
+	}, nil
+}
+
+func trimHeader(size int, data []byte) []byte {
+	if data == nil || len(data) < size {
+		return data
+	}
+	data = data[size:]
+	if len(data) > 0 && data[0] == ' ' {
+		data = data[1:]
+	}
+	if len(data) > 0 && data[len(data)-1] == '\n' {
+		data = data[:len(data)-1]
+	}
+	return data
+}
+
+func safeCopy(b []byte) []byte {
+	if len(b) == 0 {
+		return nil
+	}
+	dst := make([]byte, len(b))
+	copy(dst, b)
+	return dst
+}

--- a/http/sse_event_test.go
+++ b/http/sse_event_test.go
@@ -1,0 +1,139 @@
+//
+//
+// Tencent is pleased to support the open source community by making tRPC available.
+//
+// Copyright (C) 2023 Tencent.
+// All rights reserved.
+//
+// If you have downloaded a copy of the tRPC source code from Tencent,
+// please note that tRPC source code is licensed under the  Apache 2.0 License,
+// A copy of the Apache 2.0 License is included in this file.
+//
+//
+
+package http
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	stdhttp "net/http"
+	"testing"
+
+	"github.com/r3labs/sse/v2"
+	"github.com/stretchr/testify/require"
+	"trpc.group/trpc-go/trpc-go/codec"
+	"trpc.group/trpc-go/trpc-go/errs"
+)
+
+type sseHandler func(*sse.Event) error
+
+func (h sseHandler) Handle(e *sse.Event) error {
+	return h(e)
+}
+
+type rspHandler func(*stdhttp.Response) error
+
+func (h rspHandler) Handle(r *stdhttp.Response) error {
+	return h(r)
+}
+
+func TestProcessEvent(t *testing.T) {
+	raw := []byte(":comment\nid: 1\nevent: message\nretry: 1000\ndata: hello\ndata: world\n\n")
+	event, err := processEvent(raw)
+	require.NoError(t, err)
+	require.Equal(t, []byte("comment"), event.Comment)
+	require.Equal(t, []byte("1"), event.ID)
+	require.Equal(t, []byte("message"), event.Event)
+	require.Equal(t, []byte("1000"), event.Retry)
+	require.Equal(t, []byte("hello\nworld"), event.Data)
+}
+
+func TestClientCodecEncodeFillSSEHeaders(t *testing.T) {
+	_, msg := codec.WithNewMessage(context.Background())
+	defer codec.PutBackMessage(msg)
+	reqHead := &ClientReqHeader{}
+	rspHead := &ClientRspHeader{SSEHandler: sseHandler(func(*sse.Event) error { return nil })}
+	msg.WithClientReqHead(reqHead)
+	msg.WithClientRspHead(rspHead)
+
+	_, err := DefaultClientCodec.Encode(msg, nil)
+	require.NoError(t, err)
+	require.Equal(t, "text/event-stream", reqHead.Header.Get("Accept"))
+	require.Equal(t, "keep-alive", reqHead.Header.Get(Connection))
+	require.Equal(t, "no-cache", reqHead.Header.Get("Cache-Control"))
+}
+
+func TestClientCodecDecodeSSE(t *testing.T) {
+	_, msg := codec.WithNewMessage(context.Background())
+	defer codec.PutBackMessage(msg)
+	var data []byte
+	msg.WithClientRspHead(&ClientRspHeader{
+		Response: newHTTPResponse("event: message\ndata: hello\n\n"),
+		SSEHandler: sseHandler(func(e *sse.Event) error {
+			data = append(data, e.Data...)
+			return nil
+		}),
+	})
+
+	body, err := DefaultClientCodec.Decode(msg, nil)
+	require.NoError(t, err)
+	require.Nil(t, body)
+	require.Equal(t, []byte("hello"), data)
+}
+
+func TestClientCodecDecodeSSEBusinessError(t *testing.T) {
+	_, msg := codec.WithNewMessage(context.Background())
+	defer codec.PutBackMessage(msg)
+	msg.WithClientRspHead(&ClientRspHeader{
+		Response: newHTTPResponse("event: message\ndata: hello\n\n"),
+		SSEHandler: sseHandler(func(*sse.Event) error {
+			return errs.New(6028, "business validation failed")
+		}),
+	})
+
+	body, err := DefaultClientCodec.Decode(msg, nil)
+	require.NoError(t, err)
+	require.Nil(t, body)
+	var e *errs.Error
+	require.True(t, errors.As(msg.ClientRspErr(), &e))
+	require.Equal(t, int32(6028), int32(e.Code))
+	require.Equal(t, errs.ErrorTypeBusiness, e.Type)
+}
+
+func TestClientCodecDecodeResponseHandler(t *testing.T) {
+	_, msg := codec.WithNewMessage(context.Background())
+	defer codec.PutBackMessage(msg)
+	var data []byte
+	msg.WithClientRspHead(&ClientRspHeader{
+		Response:     newHTTPResponse("hello"),
+		SSECondition: func(*stdhttp.Response) bool { return false },
+		ResponseHandler: rspHandler(func(r *stdhttp.Response) error {
+			buf := new(bytes.Buffer)
+			_, err := buf.ReadFrom(r.Body)
+			data = buf.Bytes()
+			return err
+		}),
+	})
+
+	body, err := DefaultClientCodec.Decode(msg, nil)
+	require.NoError(t, err)
+	require.Nil(t, body)
+	require.Equal(t, []byte("hello"), data)
+}
+
+func newHTTPResponse(body string) *stdhttp.Response {
+	return &stdhttp.Response{
+		StatusCode: stdhttp.StatusOK,
+		Header:     stdhttp.Header{"Content-Type": []string{"text/event-stream"}},
+		Body:       ioNopCloser{bytes.NewBufferString(body)},
+	}
+}
+
+type ioNopCloser struct {
+	*bytes.Buffer
+}
+
+func (c ioNopCloser) Close() error {
+	return nil
+}

--- a/http/sse_writer.go
+++ b/http/sse_writer.go
@@ -1,0 +1,114 @@
+//
+//
+// Tencent is pleased to support the open source community by making tRPC available.
+//
+// Copyright (C) 2023 Tencent.
+// All rights reserved.
+//
+// If you have downloaded a copy of the tRPC source code from Tencent,
+// please note that tRPC source code is licensed under the  Apache 2.0 License,
+// A copy of the Apache 2.0 License is included in this file.
+//
+//
+
+package http
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"strconv"
+
+	"github.com/r3labs/sse/v2"
+)
+
+// WriteSSE encodes an event to the SSE format and writes it to writer.
+func WriteSSE(writer io.Writer, event sse.Event) error {
+	var buf bytes.Buffer
+	if err := writeComment(&buf, event.Comment); err != nil {
+		return fmt.Errorf("write comment: %w", err)
+	}
+	if err := writeID(&buf, event.ID); err != nil {
+		return fmt.Errorf("write id: %w", err)
+	}
+	if err := writeEvent(&buf, event.Event); err != nil {
+		return fmt.Errorf("write event: %w", err)
+	}
+	if err := writeRetry(&buf, event.Retry); err != nil {
+		return fmt.Errorf("write retry: %w", err)
+	}
+	if err := writeData(&buf, event.Data); err != nil {
+		return fmt.Errorf("write data: %w", err)
+	}
+	buf.WriteString("\n")
+	_, err := writer.Write(buf.Bytes())
+	return err
+}
+
+func writeComment(w io.Writer, comment []byte) error {
+	if len(comment) == 0 {
+		return nil
+	}
+	if _, err := w.Write([]byte(":")); err != nil {
+		return err
+	}
+	if _, err := w.Write(comment); err != nil {
+		return err
+	}
+	_, err := w.Write([]byte("\n"))
+	return err
+}
+
+func writeID(w io.Writer, id []byte) error {
+	if len(id) == 0 {
+		return nil
+	}
+	if _, err := w.Write([]byte("id:")); err != nil {
+		return err
+	}
+	if _, err := w.Write(id); err != nil {
+		return err
+	}
+	_, err := w.Write([]byte("\n"))
+	return err
+}
+
+func writeEvent(w io.Writer, event []byte) error {
+	if len(event) == 0 {
+		return nil
+	}
+	if _, err := w.Write([]byte("event:")); err != nil {
+		return err
+	}
+	if _, err := w.Write(event); err != nil {
+		return err
+	}
+	_, err := w.Write([]byte("\n"))
+	return err
+}
+
+func writeRetry(w io.Writer, retry []byte) error {
+	retryUint, err := strconv.ParseUint(string(retry), 10, 64)
+	if err != nil || retryUint == 0 {
+		return nil
+	}
+	if _, err := w.Write([]byte("retry:")); err != nil {
+		return err
+	}
+	if _, err := w.Write(retry); err != nil {
+		return err
+	}
+	_, err = w.Write([]byte("\n"))
+	return err
+}
+
+func writeData(w io.Writer, data []byte) error {
+	if _, err := w.Write([]byte("data:")); err != nil {
+		return err
+	}
+	if _, err := w.Write(data); err != nil {
+		return err
+	}
+	_, err := w.Write([]byte("\n"))
+	return err
+}

--- a/http/sse_writer_test.go
+++ b/http/sse_writer_test.go
@@ -1,0 +1,46 @@
+//
+//
+// Tencent is pleased to support the open source community by making tRPC available.
+//
+// Copyright (C) 2023 Tencent.
+// All rights reserved.
+//
+// If you have downloaded a copy of the tRPC source code from Tencent,
+// please note that tRPC source code is licensed under the  Apache 2.0 License,
+// A copy of the Apache 2.0 License is included in this file.
+//
+//
+
+package http
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+
+	"github.com/r3labs/sse/v2"
+	"github.com/stretchr/testify/require"
+)
+
+type errorWriter struct{}
+
+func (e errorWriter) Write([]byte) (int, error) {
+	return 0, errors.New("write error")
+}
+
+func TestWriteSSE(t *testing.T) {
+	event := sse.Event{
+		Comment: []byte("comment"),
+		ID:      []byte("1"),
+		Event:   []byte("message"),
+		Retry:   []byte("1000"),
+		Data:    []byte("hello"),
+	}
+	var buf bytes.Buffer
+	require.NoError(t, WriteSSE(&buf, event))
+	require.Equal(t, ":comment\nid:1\nevent:message\nretry:1000\ndata:hello\n\n", buf.String())
+}
+
+func TestWriteSSEError(t *testing.T) {
+	require.Error(t, WriteSSE(errorWriter{}, sse.Event{Data: []byte("hello")}))
+}

--- a/http/transport.go
+++ b/http/transport.go
@@ -77,6 +77,7 @@ type ServerTransport struct {
 	reusePort   bool
 	enableH2C   bool
 	http2Config *transport.HTTP2Config
+	decorate    func(*stdhttp.Server) *stdhttp.Server
 }
 
 // NewServerTransport creates a new ServerTransport which implement transport.ServerTransport.
@@ -174,6 +175,13 @@ func (t *ServerTransport) serve(ctx context.Context, s *stdhttp.Server, opts *tr
 
 	if err := transport.SaveListener(ln); err != nil {
 		return fmt.Errorf("save http listener error: %w", err)
+	}
+
+	if t.decorate != nil {
+		s = t.decorate(s)
+		if s == nil {
+			return errors.New("http server transport decorate server returned nil")
+		}
 	}
 
 	if len(opts.TLSKeyFile) != 0 && len(opts.TLSCertFile) != 0 {
@@ -400,9 +408,6 @@ func (ct *ClientTransport) getRequest(reqHeader *ClientReqHeader,
 	if err := ct.setTransInfo(msg, req); err != nil {
 		return nil, err
 	}
-	if len(opts.TLSServerName) == 0 {
-		opts.TLSServerName = req.Host
-	}
 	return req, nil
 }
 
@@ -544,8 +549,15 @@ func (ct *ClientTransport) RoundTrip(
 	}()
 	request := req.WithContext(httptrace.WithClientTrace(reqCtx, trace))
 
+	hostName := ""
+	if req.URL != nil {
+		hostName = req.URL.Hostname()
+	}
+	if reqHeader.Host != "" {
+		hostName = reqHeader.Host
+	}
 	client, err := ct.getStdHTTPClient(opts.CACertFile, opts.TLSCertFile,
-		opts.TLSKeyFile, opts.TLSServerName, opts.TLSCertProvider)
+		opts.TLSKeyFile, opts.TLSServerName, opts.TLSCertProvider, hostName)
 	if err != nil {
 		return nil, err
 	}
@@ -612,12 +624,15 @@ func (b *responseBodyWithCancel) Close() error {
 }
 
 func (ct *ClientTransport) getStdHTTPClient(caFile, certFile,
-	keyFile, serverName, providerName string) (*stdhttp.Client, error) {
+	keyFile, serverName, providerName, hostName string) (*stdhttp.Client, error) {
 	if len(caFile) == 0 { // HTTP requests share one client.
 		return &ct.Client, nil
 	}
 
-	cacheKey := fmt.Sprintf("%s-%s-%s-%s", caFile, certFile, serverName, providerName)
+	if serverName != "" {
+		hostName = serverName
+	}
+	cacheKey := fmt.Sprintf("%s-%s-%s-%s", caFile, certFile, hostName, providerName)
 	ct.tlsLock.RLock()
 	cli, ok := ct.tlsClients[cacheKey]
 	ct.tlsLock.RUnlock()
@@ -632,7 +647,7 @@ func (ct *ClientTransport) getStdHTTPClient(caFile, certFile,
 		return cli, nil
 	}
 
-	conf, err := itls.GetClientConfig(serverName, caFile, certFile, keyFile, providerName)
+	conf, err := itls.GetClientConfig(hostName, caFile, certFile, keyFile, providerName)
 	if err != nil {
 		return nil, err
 	}

--- a/http/transport_internal_test.go
+++ b/http/transport_internal_test.go
@@ -1,0 +1,41 @@
+//
+//
+// Tencent is pleased to support the open source community by making tRPC available.
+//
+// Copyright (C) 2023 Tencent.
+// All rights reserved.
+//
+// If you have downloaded a copy of the tRPC source code from Tencent,
+// please note that tRPC source code is licensed under the  Apache 2.0 License,
+// A copy of the Apache 2.0 License is included in this file.
+//
+//
+
+package http
+
+import (
+	"context"
+	stdhttp "net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"trpc.group/trpc-go/trpc-go/codec"
+	"trpc.group/trpc-go/trpc-go/transport"
+)
+
+func TestClientTransportGetRequestDoesNotSetTLSServerNameFromHost(t *testing.T) {
+	ct := NewClientTransport(false).(*ClientTransport)
+	_, msg := codec.WithNewMessage(context.Background())
+	defer codec.PutBackMessage(msg)
+	msg.WithClientRPCName("/test")
+
+	opts := &transport.RoundTripOptions{Address: "127.0.0.1:443"}
+	req, err := ct.getRequest(&ClientReqHeader{
+		Method: stdhttp.MethodGet,
+		Host:   "example.com",
+	}, nil, msg, opts)
+
+	require.NoError(t, err)
+	require.Equal(t, "example.com", req.Host)
+	require.Empty(t, opts.TLSServerName)
+}

--- a/http/transport_options.go
+++ b/http/transport_options.go
@@ -13,7 +13,11 @@
 
 package http
 
-import "trpc.group/trpc-go/trpc-go/transport"
+import (
+	stdhttp "net/http"
+
+	"trpc.group/trpc-go/trpc-go/transport"
+)
 
 // OptServerTransport modifies ServerTransport.
 type OptServerTransport func(*ServerTransport)
@@ -36,5 +40,12 @@ func WithEnableH2C() OptServerTransport {
 func WithHTTP2Config(config *transport.HTTP2Config) OptServerTransport {
 	return func(st *ServerTransport) {
 		st.http2Config = config
+	}
+}
+
+// WithDecorateHTTPServer allows users to customize the underlying HTTP server before it serves requests.
+func WithDecorateHTTPServer(f func(*stdhttp.Server) *stdhttp.Server) OptServerTransport {
+	return func(st *ServerTransport) {
+		st.decorate = f
 	}
 }

--- a/http/transport_test.go
+++ b/http/transport_test.go
@@ -1488,6 +1488,75 @@ func TestHTTPGotConnectionRemoteAddr(t *testing.T) {
 	}
 }
 
+func TestDecorateHTTPServer(t *testing.T) {
+	wantBody := t.Name()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.Nil(t, err)
+	defer ln.Close()
+	var decorated bool
+
+	tp := thttp.NewServerTransport(newNoopStdHTTPServer, thttp.WithDecorateHTTPServer(
+		func(s *http.Server) *http.Server {
+			decorated = true
+			s.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				_, _ = w.Write([]byte(wantBody))
+			})
+			return s
+		},
+	))
+	err = tp.ListenAndServe(context.Background(), transport.WithListener(ln), transport.WithHandler(&h{}))
+	require.Nil(t, err)
+	require.True(t, decorated)
+
+	require.Eventually(t, func() bool {
+		rsp, err := http.Get("http://" + ln.Addr().String())
+		if err != nil {
+			return false
+		}
+		defer rsp.Body.Close()
+		body, err := io.ReadAll(rsp.Body)
+		return err == nil && string(body) == wantBody
+	}, time.Second, 10*time.Millisecond)
+}
+
+func TestDecorateHTTPServerWithTLS(t *testing.T) {
+	wantBody := t.Name()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.Nil(t, err)
+	defer ln.Close()
+	var decorated bool
+
+	tp := thttp.NewServerTransport(newNoopStdHTTPServer, thttp.WithDecorateHTTPServer(
+		func(s *http.Server) *http.Server {
+			decorated = true
+			s.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				_, _ = w.Write([]byte(wantBody))
+			})
+			return s
+		},
+	))
+	err = tp.ListenAndServe(context.Background(),
+		transport.WithListener(ln),
+		transport.WithHandler(&h{}),
+		transport.WithServeTLS("../testdata/server.crt", "../testdata/server.key", ""),
+	)
+	require.Nil(t, err)
+	require.True(t, decorated)
+
+	client := &http.Client{Transport: &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+	}}
+	require.Eventually(t, func() bool {
+		rsp, err := client.Get("https://" + ln.Addr().String())
+		if err != nil {
+			return false
+		}
+		defer rsp.Body.Close()
+		body, err := io.ReadAll(rsp.Body)
+		return err == nil && string(body) == wantBody
+	}, time.Second, 10*time.Millisecond)
+}
+
 type h struct{}
 
 func (*h) Handle(ctx context.Context, reqBuf []byte) (rsp []byte, err error) {

--- a/http/transport_test.go
+++ b/http/transport_test.go
@@ -32,6 +32,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/tls"
+	"crypto/x509"
 	"errors"
 	"fmt"
 	"io"
@@ -1543,8 +1544,17 @@ func TestDecorateHTTPServerWithTLS(t *testing.T) {
 	require.Nil(t, err)
 	require.True(t, decorated)
 
+	pool := x509.NewCertPool()
+	ca, err := os.ReadFile("../testdata/ca.pem")
+	require.Nil(t, err)
+	require.True(t, pool.AppendCertsFromPEM(ca))
+
 	client := &http.Client{Transport: &http.Transport{
-		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		TLSClientConfig: &tls.Config{
+			RootCAs:    pool,
+			ServerName: "localhost",
+			MinVersion: tls.VersionTLS12,
+		},
 	}}
 	require.Eventually(t, func() bool {
 		rsp, err := client.Get("https://" + ln.Addr().String())

--- a/http/value_detached_ctx.go
+++ b/http/value_detached_ctx.go
@@ -35,6 +35,14 @@ func detachCtxValue(ctx context.Context) context.Context {
 		return context.Background()
 	}
 	c := valueDetachedCtx{ctx: ctx}
+	collect(ctx, &c)
+	return &c
+}
+
+func collect(ctx context.Context, c *valueDetachedCtx) {
+	if globalScavenger.collect(c) {
+		return
+	}
 	go func() {
 		<-ctx.Done()
 		deadline, ok := ctx.Deadline()
@@ -47,7 +55,6 @@ func detachCtxValue(ctx context.Context) context.Context {
 		}
 		c.mu.Unlock()
 	}()
-	return &c
 }
 
 // Deadline implements the Deadline method of Context.

--- a/http/value_detached_ctx_scavenger.go
+++ b/http/value_detached_ctx_scavenger.go
@@ -1,0 +1,117 @@
+//
+//
+// Tencent is pleased to support the open source community by making tRPC available.
+//
+// Copyright (C) 2023 Tencent.
+// All rights reserved.
+//
+// If you have downloaded a copy of the tRPC source code from Tencent,
+// please note that tRPC source code is licensed under the  Apache 2.0 License,
+// A copy of the Apache 2.0 License is included in this file.
+//
+//
+
+package http
+
+import (
+	"reflect"
+
+	"go.uber.org/atomic"
+)
+
+var globalScavenger *scavenger
+
+func init() {
+	globalScavenger = newScavenger()
+	go globalScavenger.scavengeValueDetachedCtx()
+}
+
+type scavenger struct {
+	inprocess atomic.Uint32
+	incoming  chan *valueDetachedCtx
+	cases     []reflect.SelectCase
+	ctxs      []*valueDetachedCtx
+}
+
+const (
+	incomingChanSize    = 1024
+	indexOfIncomingChan = 0
+)
+
+var limitedCases uint32 = 50000
+
+func newScavenger() *scavenger {
+	incoming := make(chan *valueDetachedCtx, incomingChanSize)
+	return &scavenger{
+		incoming: incoming,
+		cases: []reflect.SelectCase{
+			{
+				Dir:  reflect.SelectRecv,
+				Chan: reflect.ValueOf(incoming),
+			},
+		},
+		ctxs: []*valueDetachedCtx{{}},
+	}
+}
+
+func (s *scavenger) collect(c *valueDetachedCtx) bool {
+	if s.inprocess.Inc() >= limitedCases {
+		s.inprocess.Dec()
+		return false
+	}
+	s.incoming <- c
+	return true
+}
+
+func (s *scavenger) scavengeValueDetachedCtx() {
+	for {
+		chosen, recv, recvOK := reflect.Select(s.cases)
+		if chosen == indexOfIncomingChan {
+			if !recvOK {
+				continue
+			}
+			in := recv.Interface().(*valueDetachedCtx)
+			s.cases = append(s.cases, reflect.SelectCase{
+				Dir:  reflect.SelectRecv,
+				Chan: reflect.ValueOf(in.ctx.Done()),
+			})
+			s.ctxs = append(s.ctxs, in)
+			continue
+		}
+
+		c := s.ctxs[chosen]
+		ctx := c.ctx
+		deadline, ok := ctx.Deadline()
+		c.mu.Lock()
+		c.ctx = &ctxRemnant{
+			deadline:    deadline,
+			hasDeadline: ok,
+			err:         ctx.Err(),
+			done:        ctx.Done(),
+		}
+		c.mu.Unlock()
+
+		for i := chosen; i < len(s.ctxs)-1; i++ {
+			s.cases[i] = s.cases[i+1]
+			s.ctxs[i] = s.ctxs[i+1]
+		}
+		s.cases[len(s.cases)-1] = reflect.SelectCase{}
+		s.ctxs[len(s.ctxs)-1] = nil
+		s.cases = s.cases[:len(s.cases)-1]
+		s.ctxs = s.ctxs[:len(s.ctxs)-1]
+
+		const minSelectCasesCap = 1024
+		currentCap := cap(s.cases)
+		currentLen := len(s.cases)
+		if currentLen < currentCap/2 && currentCap/2 >= minSelectCasesCap {
+			newCap := currentCap / 2
+			newCases := make([]reflect.SelectCase, currentLen, newCap)
+			newCtxs := make([]*valueDetachedCtx, currentLen, newCap)
+			copy(newCases, s.cases)
+			copy(newCtxs, s.ctxs)
+			s.cases = newCases
+			s.ctxs = newCtxs
+		}
+		s.inprocess.Dec()
+	}
+}

--- a/http/value_detached_ctx_scavenger_test.go
+++ b/http/value_detached_ctx_scavenger_test.go
@@ -1,0 +1,66 @@
+//
+//
+// Tencent is pleased to support the open source community by making tRPC available.
+//
+// Copyright (C) 2023 Tencent.
+// All rights reserved.
+//
+// If you have downloaded a copy of the tRPC source code from Tencent,
+// please note that tRPC source code is licensed under the  Apache 2.0 License,
+// A copy of the Apache 2.0 License is included in this file.
+//
+//
+
+package http
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestValueDetachedContextScavenger(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	c := &valueDetachedCtx{ctx: ctx}
+	s := newScavenger()
+	go s.scavengeValueDetachedCtx()
+	require.True(t, s.collect(c))
+	require.Eventually(t, func() bool {
+		return len(s.cases) == 2 && len(s.ctxs) == 2 && s.ctxs[1] == c
+	}, time.Second, time.Millisecond)
+
+	cancel()
+	require.Eventually(t, func() bool {
+		return len(s.cases) == 1 && len(s.ctxs) == 1 && s.inprocess.Load() == 0
+	}, time.Second, time.Millisecond)
+}
+
+func TestValueDetachedContextScavengerLimited(t *testing.T) {
+	oldLimitedCases := limitedCases
+	limitedCases = 10
+	defer func() {
+		limitedCases = oldLimitedCases
+	}()
+
+	s := newScavenger()
+	go s.scavengeValueDetachedCtx()
+	var cancels []context.CancelFunc
+	var failed bool
+	for i := uint32(0); i < limitedCases+20; i++ {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancels = append(cancels, cancel)
+		if !s.collect(&valueDetachedCtx{ctx: ctx}) {
+			failed = true
+		}
+	}
+	require.True(t, failed)
+
+	for _, cancel := range cancels {
+		cancel()
+	}
+	require.Eventually(t, func() bool {
+		return len(s.cases) == 1 && len(s.ctxs) == 1 && s.inprocess.Load() == 0
+	}, time.Second, time.Millisecond)
+}

--- a/internal/httprule/parse.go
+++ b/internal/httprule/parse.go
@@ -33,6 +33,7 @@ var (
 	errDeepWildcard     = errors.New("deep wildcard must be the last segment")
 	errDupFieldPath     = errors.New("dup field path")
 	errLeadingSlash     = errors.New("leading slash required")
+	errTrailingSlash    = errors.New("trailing slash is not allowed")
 )
 
 // parser is the template parser.
@@ -167,6 +168,9 @@ func (p *parser) parseSegments() ([]segment, error) {
 	result := []segment{seg}
 
 	if err := p.consume('/'); err == nil {
+		if p.done() {
+			return nil, errTrailingSlash
+		}
 		// parse segments recursively.
 		segs, err := p.parseSegments()
 		if err != nil {

--- a/internal/httprule/parse_test.go
+++ b/internal/httprule/parse_test.go
@@ -214,6 +214,11 @@ func TestValidateTemplate(t *testing.T) {
 			wantErr: nil,
 			desc:    "validate tpl test 06",
 		},
+		{
+			input:   "/v1/a/b/c/",
+			wantErr: errTrailingSlash,
+			desc:    "validate tpl test 07",
+		},
 	} {
 		_, gotErr := Parse(test.input)
 		require.Equal(t, errors.Unwrap(gotErr), test.wantErr, test.desc)

--- a/naming/internal/registry/node.go
+++ b/naming/internal/registry/node.go
@@ -1,0 +1,32 @@
+//
+//
+// Tencent is pleased to support the open source community by making tRPC available.
+//
+// Copyright (C) 2023 Tencent.
+// All rights reserved.
+//
+// If you have downloaded a copy of the tRPC source code from Tencent,
+// please note that tRPC source code is licensed under the  Apache 2.0 License,
+// A copy of the Apache 2.0 License is included in this file.
+//
+//
+
+package registry
+
+import publicregistry "trpc.group/trpc-go/trpc-go/naming/registry"
+
+// DeepCopyNode returns a copy of node so selectors can attach per-call metadata
+// without mutating discovery or load-balance snapshots.
+func DeepCopyNode(node *publicregistry.Node) *publicregistry.Node {
+	if node == nil {
+		return nil
+	}
+	nodeCopy := *node
+	if node.Metadata != nil {
+		nodeCopy.Metadata = make(map[string]interface{}, len(node.Metadata))
+		for k, v := range node.Metadata {
+			nodeCopy.Metadata[k] = v
+		}
+	}
+	return &nodeCopy
+}

--- a/naming/internal/registry/node.go
+++ b/naming/internal/registry/node.go
@@ -11,6 +11,7 @@
 //
 //
 
+// Package registry contains helpers shared by naming implementations.
 package registry
 
 import publicregistry "trpc.group/trpc-go/trpc-go/naming/registry"

--- a/naming/internal/registry/node_test.go
+++ b/naming/internal/registry/node_test.go
@@ -1,0 +1,57 @@
+//
+//
+// Tencent is pleased to support the open source community by making tRPC available.
+//
+// Copyright (C) 2023 Tencent.
+// All rights reserved.
+//
+// If you have downloaded a copy of the tRPC source code from Tencent,
+// please note that tRPC source code is licensed under the  Apache 2.0 License,
+// A copy of the Apache 2.0 License is included in this file.
+//
+//
+
+package registry
+
+import (
+	"testing"
+
+	publicregistry "trpc.group/trpc-go/trpc-go/naming/registry"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDeepCopyNode(t *testing.T) {
+	node := &publicregistry.Node{
+		ServiceName: "trpc.test.helloworld.Greeter",
+		Address:     "127.0.0.1:8000",
+		Metadata: map[string]interface{}{
+			"key": "value",
+		},
+	}
+
+	nodeCopy := DeepCopyNode(node)
+	require.NotSame(t, node, nodeCopy)
+	require.Equal(t, node, nodeCopy)
+	require.NotSame(t, node.Metadata, nodeCopy.Metadata)
+
+	nodeCopy.Metadata["key"] = "changed"
+	require.Equal(t, "value", node.Metadata["key"])
+}
+
+func TestDeepCopyNodeNil(t *testing.T) {
+	require.Nil(t, DeepCopyNode(nil))
+}
+
+func TestDeepCopyNodeCopiesEmptyMetadata(t *testing.T) {
+	node := &publicregistry.Node{
+		Address:  "127.0.0.1:8000",
+		Metadata: map[string]interface{}{},
+	}
+
+	nodeCopy := DeepCopyNode(node)
+	require.NotSame(t, node.Metadata, nodeCopy.Metadata)
+
+	nodeCopy.Metadata["key"] = "value"
+	require.Empty(t, node.Metadata)
+}

--- a/naming/loadbalance/consistenthash/consistenthash.go
+++ b/naming/loadbalance/consistenthash/consistenthash.go
@@ -129,6 +129,7 @@ func (p *chPicker) Pick(list []*registry.Node, opts *loadbalance.Options) (*regi
 		return internalregistry.DeepCopyNode(nodes[0]), nil
 	default:
 		innerIndex := p.hashFunc(innerRepr(opts.Key))
+		// #nosec G115: the modulo result is always smaller than len(nodes).
 		pos := int(innerIndex % uint64(len(nodes)))
 		return internalregistry.DeepCopyNode(nodes[pos]), nil
 	}

--- a/naming/loadbalance/consistenthash/consistenthash.go
+++ b/naming/loadbalance/consistenthash/consistenthash.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/cespare/xxhash"
+	internalregistry "trpc.group/trpc-go/trpc-go/naming/internal/registry"
 	"trpc.group/trpc-go/trpc-go/naming/loadbalance"
 	"trpc.group/trpc-go/trpc-go/naming/registry"
 )
@@ -125,11 +126,11 @@ func (p *chPicker) Pick(list []*registry.Node, opts *loadbalance.Options) (*regi
 	}
 	switch len(nodes) {
 	case 1:
-		return nodes[0], nil
+		return internalregistry.DeepCopyNode(nodes[0]), nil
 	default:
 		innerIndex := p.hashFunc(innerRepr(opts.Key))
 		pos := int(innerIndex % uint64(len(nodes)))
-		return nodes[pos], nil
+		return internalregistry.DeepCopyNode(nodes[pos]), nil
 	}
 }
 

--- a/naming/loadbalance/random.go
+++ b/naming/loadbalance/random.go
@@ -18,6 +18,7 @@ import (
 
 	"trpc.group/trpc-go/trpc-go/internal/rand"
 	"trpc.group/trpc-go/trpc-go/naming/bannednodes"
+	internalregistry "trpc.group/trpc-go/trpc-go/naming/internal/registry"
 	"trpc.group/trpc-go/trpc-go/naming/registry"
 )
 
@@ -75,7 +76,7 @@ func (b *Random) chooseOne(nodes []*registry.Node) (*registry.Node, error) {
 	if len(nodes) == 0 {
 		return nil, ErrNoServerAvailable
 	}
-	return nodes[b.safeRand.Intn(len(nodes))], nil
+	return internalregistry.DeepCopyNode(nodes[b.safeRand.Intn(len(nodes))]), nil
 }
 
 func (b *Random) chooseUnbanned(
@@ -86,10 +87,13 @@ func (b *Random) chooseUnbanned(
 		return nil, ErrNoServerAvailable
 	}
 	i := b.safeRand.Intn(len(nodes))
-	if !bans.Range(func(n *registry.Node) bool {
-		return n.Address != nodes[i].Address
-	}) {
-		return b.chooseUnbanned(append(nodes[:i], nodes[i+1:]...), bans)
+	for offset := 0; offset < len(nodes); offset++ {
+		node := nodes[(i+offset)%len(nodes)]
+		if bans.Range(func(n *registry.Node) bool {
+			return n.Address != node.Address
+		}) {
+			return internalregistry.DeepCopyNode(node), nil
+		}
 	}
-	return nodes[i], nil
+	return nil, ErrNoServerAvailable
 }

--- a/naming/loadbalance/roundrobin/roundrobin.go
+++ b/naming/loadbalance/roundrobin/roundrobin.go
@@ -18,6 +18,7 @@ import (
 	"sync"
 	"time"
 
+	internalregistry "trpc.group/trpc-go/trpc-go/naming/internal/registry"
 	"trpc.group/trpc-go/trpc-go/naming/loadbalance"
 	"trpc.group/trpc-go/trpc-go/naming/registry"
 )
@@ -86,7 +87,7 @@ func (p *rrPicker) Pick(list []*registry.Node, opts *loadbalance.Options) (*regi
 	}
 	node := p.list[p.next]
 	p.next = (p.next + 1) % len(p.list)
-	return node, nil
+	return internalregistry.DeepCopyNode(node), nil
 }
 
 func (p *rrPicker) updateState(list []*registry.Node) {

--- a/naming/loadbalance/weightroundrobin/weightroundrobin.go
+++ b/naming/loadbalance/weightroundrobin/weightroundrobin.go
@@ -18,6 +18,7 @@ import (
 	"sync"
 	"time"
 
+	internalregistry "trpc.group/trpc-go/trpc-go/naming/internal/registry"
 	"trpc.group/trpc-go/trpc-go/naming/loadbalance"
 	"trpc.group/trpc-go/trpc-go/naming/registry"
 )
@@ -92,7 +93,7 @@ func (p *wrrPicker) Pick(list []*registry.Node, opts *loadbalance.Options) (*reg
 		return nil, loadbalance.ErrNoServerAvailable
 	}
 	selected := p.selectServer()
-	return selected.node, nil
+	return internalregistry.DeepCopyNode(selected.node), nil
 }
 
 func (p *wrrPicker) selectServer() *Server {

--- a/server/server.go
+++ b/server/server.go
@@ -30,10 +30,13 @@ type Server struct {
 
 	services map[string]Service // k=serviceName,v=Service
 
-	mux sync.Mutex // guards onShutdownHooks
+	mux sync.Mutex // guards onShutdownHooks and afterShutdownHooks
 	// onShutdownHooks are hook functions that would be executed when server is
 	// shutting down (before closing all services of the server).
 	onShutdownHooks []func()
+	// afterShutdownHooks are hook functions that would be executed after closing
+	// all services of the server.
+	afterShutdownHooks []func()
 
 	failedServices sync.Map
 	signalCh       chan os.Signal
@@ -137,16 +140,33 @@ func (s *Server) tryClose() {
 			}(service)
 		}
 		wg.Wait()
+
+		s.mux.Lock()
+		for _, f := range s.afterShutdownHooks {
+			f()
+		}
+		s.mux.Unlock()
 	}
 	s.closeOnce.Do(fn)
 }
 
-// RegisterOnShutdown registers a hook function that would be executed when server is shutting down.
+// RegisterOnShutdown registers a hook function that would be executed when server is shutting down
+// before closing all services of the server.
 func (s *Server) RegisterOnShutdown(fn func()) {
 	if fn == nil {
 		return
 	}
 	s.mux.Lock()
 	s.onShutdownHooks = append(s.onShutdownHooks, fn)
+	s.mux.Unlock()
+}
+
+// RegisterAfterShutdown registers a hook function that would be executed after closing all services.
+func (s *Server) RegisterAfterShutdown(fn func()) {
+	if fn == nil {
+		return
+	}
+	s.mux.Lock()
+	s.afterShutdownHooks = append(s.afterShutdownHooks, fn)
 	s.mux.Unlock()
 }

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -275,3 +275,43 @@ func TestServer_AtExit_ExecuteOrder(t *testing.T) {
 	_, ok := <-ch
 	require.False(t, ok)
 }
+
+func TestServerRegisterAfterShutdown(t *testing.T) {
+	s := &server.Server{}
+	ch := make(chan string, 5)
+	s.AddService("trpc.app.server.service", &closeOrderService{name: "service", ch: ch})
+	s.RegisterOnShutdown(func() { ch <- "before1" })
+	s.RegisterOnShutdown(func() { ch <- "before2" })
+	s.RegisterAfterShutdown(func() { ch <- "after1" })
+	s.RegisterAfterShutdown(func() { ch <- "after2" })
+
+	require.Nil(t, s.Close(nil))
+	require.Equal(t, "before1", <-ch)
+	require.Equal(t, "before2", <-ch)
+	require.Equal(t, "service", <-ch)
+	require.Equal(t, "after1", <-ch)
+	require.Equal(t, "after2", <-ch)
+}
+
+type closeOrderService struct {
+	name string
+	ch   chan string
+}
+
+func (s *closeOrderService) Register(interface{}, interface{}) error {
+	return nil
+}
+
+func (s *closeOrderService) Serve() error {
+	return nil
+}
+
+func (s *closeOrderService) ServiceName() string {
+	return s.name
+}
+
+func (s *closeOrderService) Close(ch chan struct{}) error {
+	ch <- struct{}{}
+	s.ch <- s.name
+	return nil
+}

--- a/stream/client.go
+++ b/stream/client.go
@@ -234,7 +234,10 @@ func (cs *clientStream) invoke(ctx context.Context, _ *client.ClientStreamDesc) 
 	if err := cs.stream.Invoke(ctx); err != nil {
 		return nil, err
 	}
-	w := getWindowSize(cs.opts.MaxWindowSize)
+	var w uint32
+	if !cs.opts.DisabledFlowControl {
+		w = getWindowSize(cs.opts.MaxWindowSize)
+	}
 	newCtx, newMsg := codec.WithCloneContextAndMessage(ctx)
 	defer codec.PutBackMessage(newMsg)
 	copyMetaData(newMsg, codec.Message(cs.ctx))
@@ -246,11 +249,14 @@ func (cs *clientStream) invoke(ctx context.Context, _ *client.ClientStreamDesc) 
 		RequestMeta:    &trpcpb.TrpcStreamInitRequestMeta{},
 		InitWindowSize: w,
 	})
-	cs.opts.RControl = newReceiveControl(w, cs.feedback)
+	if cs.opts.RControl == nil {
+		cs.opts.RControl = newReceiveControl(w, cs.feedback)
+	}
 	// Send the init message out.
 	if err := cs.stream.Send(newCtx, nil); err != nil {
 		return nil, err
 	}
+	go cs.monitorContextCancellation()
 	// After init is sent, the server will return directly.
 	if _, err := cs.stream.Recv(newCtx); err != nil {
 		return nil, err
@@ -269,6 +275,15 @@ func (cs *clientStream) invoke(ctx context.Context, _ *client.ClientStreamDesc) 
 	return cs, nil
 }
 
+func (cs *clientStream) monitorContextCancellation() {
+	select {
+	case <-cs.ctx.Done():
+		cs.opts.StreamTransport.Close(cs.ctx)
+		cs.close()
+	case <-cs.closeCh:
+	}
+}
+
 // configSendControl configs Send Control according to initWindowSize.
 func (cs *clientStream) configSendControl(initWindowSize uint32) {
 	if initWindowSize == 0 {
@@ -277,7 +292,9 @@ func (cs *clientStream) configSendControl(initWindowSize uint32) {
 		cs.opts.SControl = nil
 		return
 	}
-	cs.opts.SControl = newSendControl(initWindowSize, cs.ctx.Done(), cs.closeCh)
+	if cs.opts.SControl == nil {
+		cs.opts.SControl = newSendControl(initWindowSize, cs.ctx.Done(), cs.closeCh)
+	}
 }
 
 // feedback send feedback frame.

--- a/stream/client_test.go
+++ b/stream/client_test.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"sync"
 	"testing"
 	"time"
 
@@ -108,6 +109,53 @@ func (c *fakeCodec) Decode(msg codec.Msg, rspBuf []byte) (rspBody []byte, err er
 		return nil, nil
 	}
 	return rspBuf, nil
+}
+
+type blockingStreamTransport struct {
+	closed chan struct{}
+	once   sync.Once
+}
+
+func newBlockingStreamTransport() *blockingStreamTransport {
+	return &blockingStreamTransport{closed: make(chan struct{})}
+}
+
+func (t *blockingStreamTransport) Send(context.Context, []byte, ...transport.RoundTripOption) error {
+	return nil
+}
+
+func (t *blockingStreamTransport) Recv(context.Context, ...transport.RoundTripOption) ([]byte, error) {
+	<-t.closed
+	return nil, context.Canceled
+}
+
+func (t *blockingStreamTransport) Init(context.Context, ...transport.RoundTripOption) error {
+	return nil
+}
+
+func (t *blockingStreamTransport) Close(context.Context) {
+	t.once.Do(func() {
+		close(t.closed)
+	})
+}
+
+var (
+	errCustomSendControl = errors.New("custom send control")
+	errCustomRecvControl = errors.New("custom recv control")
+)
+
+type failingSendControl struct{}
+
+func (failingSendControl) GetWindow(uint32) error {
+	return errCustomSendControl
+}
+
+func (failingSendControl) UpdateWindow(uint32) {}
+
+type failingRecvControl struct{}
+
+func (failingRecvControl) OnRecv(uint32) error {
+	return errCustomRecvControl
 }
 
 // TestMain tests the Main function.
@@ -265,6 +313,59 @@ func TestClientFlowControl(t *testing.T) {
 	err = cs.RecvMsg(rspBody)
 	assert.Equal(t, io.EOF, err)
 	assert.Nil(t, rspBody.Data)
+}
+
+func TestClientCustomFlowControl(t *testing.T) {
+	codec.RegisterSerializer(0, &codec.NoopSerialization{})
+	codec.Register("custom-flow-control", nil, &fakeCodec{})
+
+	t.Run("send control", func(t *testing.T) {
+		tp := &fakeTransport{expectChan: make(chan recvExpect, 1)}
+		tp.expectChan <- func(fh *trpc.FrameHead, m codec.Msg) ([]byte, error) {
+			fh.StreamFrameType = uint8(trpcpb.TrpcStreamFrameType_TRPC_STREAM_FRAME_INIT)
+			m.WithStreamFrame(&trpcpb.TrpcStreamInitMeta{InitWindowSize: 2000})
+			return nil, nil
+		}
+		cs, err := stream.NewStreamClient().NewStream(ctx, &client.ClientStreamDesc{}, "",
+			client.WithProtocol("custom-flow-control"),
+			client.WithTarget("ip://127.0.0.1:8000"),
+			client.WithCurrentSerializationType(codec.SerializationTypeNoop),
+			client.WithStreamTransport(tp),
+			client.WithSendControl(failingSendControl{}),
+		)
+		assert.Nil(t, err)
+		assert.NotNil(t, cs)
+		assert.ErrorIs(t, cs.SendMsg(&codec.Body{Data: []byte("body")}), errCustomSendControl)
+		tp.expectChan <- func(fh *trpc.FrameHead, m codec.Msg) ([]byte, error) {
+			return nil, errors.New("close")
+		}
+	})
+
+	t.Run("recv control", func(t *testing.T) {
+		tp := &fakeTransport{expectChan: make(chan recvExpect, 2)}
+		tp.expectChan <- func(fh *trpc.FrameHead, m codec.Msg) ([]byte, error) {
+			fh.StreamFrameType = uint8(trpcpb.TrpcStreamFrameType_TRPC_STREAM_FRAME_INIT)
+			m.WithStreamFrame(&trpcpb.TrpcStreamInitMeta{InitWindowSize: 2000})
+			return nil, nil
+		}
+		cs, err := stream.NewStreamClient().NewStream(ctx, &client.ClientStreamDesc{ServerStreams: true}, "",
+			client.WithProtocol("custom-flow-control"),
+			client.WithTarget("ip://127.0.0.1:8000"),
+			client.WithCurrentSerializationType(codec.SerializationTypeNoop),
+			client.WithStreamTransport(tp),
+			client.WithRecvControl(failingRecvControl{}),
+		)
+		assert.Nil(t, err)
+		assert.NotNil(t, cs)
+		tp.expectChan <- func(fh *trpc.FrameHead, m codec.Msg) ([]byte, error) {
+			fh.StreamFrameType = uint8(trpcpb.TrpcStreamFrameType_TRPC_STREAM_FRAME_DATA)
+			return []byte("body"), nil
+		}
+		assert.ErrorIs(t, cs.RecvMsg(&codec.Body{}), errCustomRecvControl)
+		tp.expectChan <- func(fh *trpc.FrameHead, m codec.Msg) ([]byte, error) {
+			return nil, errors.New("close")
+		}
+	})
 }
 
 // TestClientError tests the case of streaming Client error handling.
@@ -801,6 +902,31 @@ func TestClientNewStreamFail(t *testing.T) {
 		assert.NotNil(t, err)
 		assert.True(t, isClosed)
 	})
+}
+
+func TestClientNewStreamCloseTransportWhenInitRecvBlocks(t *testing.T) {
+	codec.Register("blocking_stream_timeout", nil, &fakeCodec{})
+	tp := newBlockingStreamTransport()
+	timeoutCtx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := stream.NewStreamClient().NewStream(timeoutCtx, &client.ClientStreamDesc{}, "",
+			client.WithProtocol("blocking_stream_timeout"),
+			client.WithTarget("ip://127.0.0.1:8000"),
+			client.WithCurrentSerializationType(codec.SerializationTypeNoop),
+			client.WithStreamTransport(tp),
+		)
+		done <- err
+	}()
+
+	select {
+	case err := <-done:
+		assert.ErrorIs(t, err, context.Canceled)
+	case <-time.After(time.Second):
+		assert.Fail(t, "NewStream should return after context timeout")
+	}
 }
 
 func TestClientServerCompress(t *testing.T) {


### PR DESCRIPTION
## Summary

- sync selected low-risk stability fixes for HTTP, stream, naming, RESTful, httprule, and value-detached HTTP contexts
- add additive public features: standard HTTP SSE handling/writing, HTTP server decoration, stream flow-control options, server after-shutdown hooks, and GET serialization case-sensitive construction
- keep larger or dependency-heavy items out of this PR, including fasthttp transport, tnet UDP, prewarm/precool, keeporder, overloadctrl, and protocol/dependency changes

## Compatibility

- default behavior is preserved unless callers opt into new APIs
- no internal domains, internal module paths, or local environment-specific content are included
- new dependency is the public github.com/r3labs/sse/v2 package used for SSE event parsing/writing

## Validation

- go test ./...
- go test ./client ./server ./http ./stream ./naming/... ./internal/httprule
- git diff --check
- scanned changed code and sync notes for internal domains, local paths, and tool signatures