### PR TITLE
transport: report partial read timeout as read failure

### DIFF
--- a/transport/read_counting_reader.go
+++ b/transport/read_counting_reader.go
@@ -1,0 +1,39 @@
+//
+//
+// Tencent is pleased to support the open source community by making tRPC available.
+//
+// Copyright (C) 2023 Tencent.
+// All rights reserved.
+//
+// If you have downloaded a copy of the tRPC source code from Tencent,
+// please note that tRPC source code is licensed under the  Apache 2.0 License,
+// A copy of the Apache 2.0 License is included in this file.
+//
+//
+
+package transport
+
+import "io"
+
+type readCountingReader struct {
+	r         io.Reader
+	readBytes int
+}
+
+func newReadCountingReader(r io.Reader) *readCountingReader {
+	return &readCountingReader{r: r}
+}
+
+func (r *readCountingReader) Read(p []byte) (int, error) {
+	n, err := r.r.Read(p)
+	r.readBytes += n
+	return n, err
+}
+
+func (r *readCountingReader) ReadBytes() int {
+	return r.readBytes
+}
+
+func (r *readCountingReader) ResetReadBytes() {
+	r.readBytes = 0
+}

--- a/transport/server_transport_tcp.go
+++ b/transport/server_transport_tcp.go
@@ -119,10 +119,12 @@ func (s *serverTransport) serveTCP(ctx context.Context, ln net.Listener, opts *L
 				}
 			}
 		}
+		reader := newReadCountingReader(codec.NewReader(rwc))
 		tc := &tcpconn{
 			conn:        s.newConn(ctx, opts),
 			rwc:         rwc,
-			fr:          opts.FramerBuilder.New(codec.NewReader(rwc)),
+			fr:          opts.FramerBuilder.New(reader),
+			readCounter: reader,
 			remoteAddr:  rwc.RemoteAddr(),
 			localAddr:   rwc.LocalAddr(),
 			serverAsync: opts.ServerAsync,
@@ -165,6 +167,7 @@ type tcpconn struct {
 	*conn
 	rwc         net.Conn
 	fr          codec.Framer
+	readCounter *readCountingReader
 	localAddr   net.Addr
 	remoteAddr  net.Addr
 	serverAsync bool
@@ -242,6 +245,9 @@ func (c *tcpconn) serve() {
 			}
 		}
 
+		if c.readCounter != nil {
+			c.readCounter.ResetReadBytes()
+		}
 		req, err := c.fr.ReadFrame()
 		if err != nil {
 			if err == io.EOF {
@@ -250,6 +256,11 @@ func (c *tcpconn) serve() {
 			}
 			// Server closes the connection if client sends no package in last idle timeout.
 			if e, ok := err.(net.Error); ok && e.Timeout() {
+				if c.readCounter != nil && c.readCounter.ReadBytes() > 0 {
+					report.TCPServerTransportReadFail.Incr()
+					log.Trace("transport: tcpconn serve ReadFrame timeout after partial read ", err)
+					return
+				}
 				report.TCPServerTransportIdleTimeout.Incr()
 				return
 			}

--- a/transport/server_transport_test.go
+++ b/transport/server_transport_test.go
@@ -19,6 +19,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net"
 	"runtime"
 	"sync"
@@ -29,7 +30,9 @@ import (
 	"github.com/stretchr/testify/require"
 
 	_ "trpc.group/trpc-go/trpc-go"
+	"trpc.group/trpc-go/trpc-go/codec"
 	"trpc.group/trpc-go/trpc-go/errs"
+	"trpc.group/trpc-go/trpc-go/metrics"
 	"trpc.group/trpc-go/trpc-go/transport"
 )
 
@@ -83,6 +86,148 @@ func TestTCPListenAndServe(t *testing.T) {
 		transport.WithDialAddress(addr),
 		transport.WithClientFramerBuilder(&framerBuilder{}))
 	assert.NotNil(t, err)
+}
+
+func TestTCPListenAndServeReportsReadFailOnPartialReadTimeout(t *testing.T) {
+	const (
+		sinkName       = "tcp-read-fail-test"
+		readFailMetric = "trpc.TcpServerTransportReadFail"
+		idleMetric     = "trpc.TcpServerTransportIdleTimeout"
+	)
+
+	sink := newCountingMetricsSink(sinkName)
+	metrics.RegisterMetricsSink(sink)
+	defer metrics.RegisterMetricsSink(newNoopMetricsSink(sinkName))
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer ln.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	st := transport.NewServerTransport(transport.WithReusePort(false))
+	err = st.ListenAndServe(ctx,
+		transport.WithListener(ln),
+		transport.WithServerFramerBuilder(&partialReadTimeoutFramerBuilder{}),
+		transport.WithServerIdleTimeout(20*time.Millisecond),
+		transport.WithHandler(&echoHandler{}),
+	)
+	require.NoError(t, err)
+
+	conn, err := net.Dial("tcp", ln.Addr().String())
+	require.NoError(t, err)
+	defer conn.Close()
+	_, err = conn.Write([]byte{1})
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		return sink.Count(readFailMetric) > 0
+	}, time.Second, 10*time.Millisecond)
+	assert.Equal(t, 0, sink.Count(idleMetric))
+}
+
+func TestTCPListenAndServeReportsIdleTimeoutWithoutPartialRead(t *testing.T) {
+	const (
+		sinkName       = "tcp-idle-timeout-test"
+		readFailMetric = "trpc.TcpServerTransportReadFail"
+		idleMetric     = "trpc.TcpServerTransportIdleTimeout"
+	)
+
+	sink := newCountingMetricsSink(sinkName)
+	metrics.RegisterMetricsSink(sink)
+	defer metrics.RegisterMetricsSink(newNoopMetricsSink(sinkName))
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer ln.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	st := transport.NewServerTransport(transport.WithReusePort(false))
+	err = st.ListenAndServe(ctx,
+		transport.WithListener(ln),
+		transport.WithServerFramerBuilder(&partialReadTimeoutFramerBuilder{}),
+		transport.WithServerIdleTimeout(20*time.Millisecond),
+		transport.WithHandler(&echoHandler{}),
+	)
+	require.NoError(t, err)
+
+	conn, err := net.Dial("tcp", ln.Addr().String())
+	require.NoError(t, err)
+	defer conn.Close()
+
+	require.Eventually(t, func() bool {
+		return sink.Count(idleMetric) > 0
+	}, time.Second, 10*time.Millisecond)
+	assert.Equal(t, 0, sink.Count(readFailMetric))
+}
+
+type countingMetricsSink struct {
+	name   string
+	mu     sync.Mutex
+	counts map[string]int
+}
+
+func newCountingMetricsSink(name string) *countingMetricsSink {
+	return &countingMetricsSink{
+		name:   name,
+		counts: make(map[string]int),
+	}
+}
+
+func (s *countingMetricsSink) Name() string {
+	return s.name
+}
+
+func (s *countingMetricsSink) Report(rec metrics.Record, opts ...metrics.Option) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, m := range rec.GetMetrics() {
+		s.counts[m.Name()]++
+	}
+	return nil
+}
+
+func (s *countingMetricsSink) Count(name string) int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.counts[name]
+}
+
+type noopMetricsSink struct {
+	name string
+}
+
+func newNoopMetricsSink(name string) *noopMetricsSink {
+	return &noopMetricsSink{name: name}
+}
+
+func (s *noopMetricsSink) Name() string {
+	return s.name
+}
+
+func (s *noopMetricsSink) Report(metrics.Record, ...metrics.Option) error {
+	return nil
+}
+
+type partialReadTimeoutFramerBuilder struct{}
+
+func (b *partialReadTimeoutFramerBuilder) New(r io.Reader) codec.Framer {
+	return &partialReadTimeoutFramer{r: r}
+}
+
+type partialReadTimeoutFramer struct {
+	r io.Reader
+}
+
+func (f *partialReadTimeoutFramer) ReadFrame() ([]byte, error) {
+	buf := make([]byte, 2)
+	if _, err := io.ReadFull(f.r, buf); err != nil {
+		return nil, err
+	}
+	return buf, nil
 }
 
 func TestTCPTLSListenAndServe(t *testing.T) {


### PR DESCRIPTION
## Summary

- track bytes consumed while reading TCP frames
- report timeouts after partial frame reads as `TcpServerTransportReadFail`
- keep empty idle timeouts on `TcpServerTransportIdleTimeout`

## Tests

- go test ./transport -count=1
- go test ./... -count=1
