### PR TITLE
http: support FastHTTP transport

### DIFF
--- a/http/README.md
+++ b/http/README.md
@@ -10,6 +10,45 @@ The tRPC-Go framework supports building three types of HTTP-related services:
 
 The RESTful related documentation is available in [/restful](/restful/)
 
+## FastHTTP transport
+
+tRPC-Go also provides FastHTTP-based client and server transport support.
+Use protocol `fasthttp` for HTTP RPC services and `fasthttp_no_protocol`
+for standard HTTP services implemented with `fasthttp.RequestCtx`.
+
+```yaml
+server:
+  service:
+    - name: trpc.app.server.fast
+      network: tcp
+      protocol: fasthttp_no_protocol
+      ip: 127.0.0.1
+      port: 8080
+```
+
+```go
+package main
+
+import (
+    trpc "trpc.group/trpc-go/trpc-go"
+    thttp "trpc.group/trpc-go/trpc-go/http"
+    "github.com/valyala/fasthttp"
+)
+
+func main() {
+    s := trpc.NewServer()
+    thttp.FastHTTPHandleFunc("/ping", func(ctx *fasthttp.RequestCtx) {
+        ctx.SetBodyString("pong")
+    })
+    thttp.RegisterNoProtocolService(s.Service("trpc.app.server.fast"))
+    s.Serve()
+}
+```
+
+For FastHTTP client calls that still need tRPC service discovery, filters, and
+metrics, use `NewFastHTTPClientProxy`. For direct FastHTTP-style usage, use
+`NewFastHTTPClient`.
+
 ## Pan-HTTP standard services
 
 The tRPC-Go framework provides pervasive HTTP standard service capabilities, mainly by adding service registration, service discovery, interceptors and other capabilities to the annotation library HTTP, so that the HTTP protocol can be seamlessly integrated into the tRPC ecosystem

--- a/http/README.zh_CN.md
+++ b/http/README.zh_CN.md
@@ -10,6 +10,45 @@ tRPC-Go 框架支持搭建与 HTTP 相关的三种服务:
 
 其中 RESTful 相关文档见 [/restful](/restful/)
 
+## FastHTTP transport
+
+tRPC-Go 也提供基于 FastHTTP 的客户端和服务端 transport。HTTP RPC 服务使用
+`fasthttp` 协议，基于 `fasthttp.RequestCtx` 的标准 HTTP 服务使用
+`fasthttp_no_protocol` 协议。
+
+```yaml
+server:
+  service:
+    - name: trpc.app.server.fast
+      network: tcp
+      protocol: fasthttp_no_protocol
+      ip: 127.0.0.1
+      port: 8080
+```
+
+```go
+package main
+
+import (
+    trpc "trpc.group/trpc-go/trpc-go"
+    thttp "trpc.group/trpc-go/trpc-go/http"
+    "github.com/valyala/fasthttp"
+)
+
+func main() {
+    s := trpc.NewServer()
+    thttp.FastHTTPHandleFunc("/ping", func(ctx *fasthttp.RequestCtx) {
+        ctx.SetBodyString("pong")
+    })
+    thttp.RegisterNoProtocolService(s.Service("trpc.app.server.fast"))
+    s.Serve()
+}
+```
+
+如果希望 FastHTTP 调用继续使用 tRPC 的服务发现、filter 和 metrics，可使用
+`NewFastHTTPClientProxy`。如果希望直接按 FastHTTP 风格使用，可使用
+`NewFastHTTPClient`。
+
 ## 泛 HTTP 标准服务
 
 tRPC-Go 框架提供了泛 HTTP 标准服务能力, 主要是在标准库 HTTP 的能力上添加了服务注册、服务发现、拦截器等能力, 使 HTTP 协议能够无缝接入 tRPC 生态
@@ -878,4 +917,3 @@ func (*chunkedServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	return
 }
 ```
-

--- a/http/codec.go
+++ b/http/codec.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/textproto"
 	"os"
 	"path"
 	"strconv"
@@ -37,16 +38,17 @@ import (
 
 // Constants of header keys related to trpc.
 const (
-	TrpcVersion     = "trpc-version"
-	TrpcCallType    = "trpc-call-type"
-	TrpcMessageType = "trpc-message-type"
-	TrpcRequestID   = "trpc-request-id"
-	TrpcTimeout     = "trpc-timeout"
-	TrpcCaller      = "trpc-caller"
-	TrpcCallee      = "trpc-callee"
-	TrpcTransInfo   = "trpc-trans-info"
-	TrpcEnv         = "trpc-env"
-	TrpcDyeingKey   = "trpc-dyeing-key"
+	TrpcVersion      = "trpc-version"
+	TrpcCallType     = "trpc-call-type"
+	TrpcMessageType  = "trpc-message-type"
+	TrpcRequestID    = "trpc-request-id"
+	TrpcTimeout      = "trpc-timeout"
+	TrpcCaller       = "trpc-caller"
+	TrpcCallerMethod = "trpc-caller-method"
+	TrpcCallee       = "trpc-callee"
+	TrpcTransInfo    = "trpc-trans-info"
+	TrpcEnv          = "trpc-env"
+	TrpcDyeingKey    = "trpc-dyeing-key"
 	// TrpcErrorMessage used to pass error messages,
 	// contains user code's error or frame errors (such as validation framework).
 	TrpcErrorMessage = "trpc-error-msg"
@@ -56,6 +58,27 @@ const (
 	TrpcUserFuncErrorCode = "trpc-func-ret"
 	// Connection is used to set whether connect mode is "Connection".
 	Connection = "Connection"
+)
+
+var (
+	canonicalContentType         = textproto.CanonicalMIMEHeaderKey("Content-Type")
+	canonicalXContentTypeOptions = textproto.CanonicalMIMEHeaderKey("X-Content-Type-Options")
+	canonicalContentEncoding     = textproto.CanonicalMIMEHeaderKey("Content-Encoding")
+)
+
+var (
+	canonicalTrpcVersion            = textproto.CanonicalMIMEHeaderKey(TrpcVersion)
+	canonicalTrpcCallType           = textproto.CanonicalMIMEHeaderKey(TrpcCallType)
+	canonicalTrpcMessageType        = textproto.CanonicalMIMEHeaderKey(TrpcMessageType)
+	canonicalTrpcRequestID          = textproto.CanonicalMIMEHeaderKey(TrpcRequestID)
+	canonicalTrpcTimeout            = textproto.CanonicalMIMEHeaderKey(TrpcTimeout)
+	canonicalTrpcCaller             = textproto.CanonicalMIMEHeaderKey(TrpcCaller)
+	canonicalTrpcCallerMethod       = textproto.CanonicalMIMEHeaderKey(TrpcCallerMethod)
+	canonicalTrpcCallee             = textproto.CanonicalMIMEHeaderKey(TrpcCallee)
+	canonicalTrpcTransInfo          = textproto.CanonicalMIMEHeaderKey(TrpcTransInfo)
+	canonicalTrpcErrorMessage       = textproto.CanonicalMIMEHeaderKey(TrpcErrorMessage)
+	canonicalTrpcFrameworkErrorCode = textproto.CanonicalMIMEHeaderKey(TrpcFrameworkErrorCode)
+	canonicalTrpcUserFuncErrorCode  = textproto.CanonicalMIMEHeaderKey(TrpcUserFuncErrorCode)
 )
 
 var contentTypeSerializationType = map[string]int{

--- a/http/fasthttp_client.go
+++ b/http/fasthttp_client.go
@@ -1,0 +1,203 @@
+//
+//
+// Tencent is pleased to support the open source community by making tRPC available.
+//
+// Copyright (C) 2023 Tencent.
+// All rights reserved.
+//
+// If you have downloaded a copy of the tRPC source code from Tencent,
+// please note that tRPC source code is licensed under the  Apache 2.0 License,
+// A copy of the Apache 2.0 License is included in this file.
+//
+//
+
+package http
+
+import (
+	"context"
+	"strings"
+
+	"github.com/valyala/fasthttp"
+	"trpc.group/trpc-go/trpc-go/client"
+	"trpc.group/trpc-go/trpc-go/codec"
+	"trpc.group/trpc-go/trpc-go/errs"
+)
+
+const (
+	fastHTTPProtocol           = "fasthttp"
+	fastHTTPNoProtocolProtocol = "fasthttp_no_protocol"
+)
+
+// FastHTTPCli is the struct for invoking service based on http.
+type FastHTTPCli struct {
+	serviceName string
+	client      client.Client
+	opts        []client.Option
+}
+
+// NewFastHTTPClientProxy creates a new fasthttp backend request proxy.
+// Parameter name means the name of backend http service (e.g. trpc.http.xxx.xxx),
+// mainly used for metrics, can be freely defined but
+// format needs to follow "trpc.app.server.service".
+var NewFastHTTPClientProxy = func(name string, opts ...client.Option) *FastHTTPCli {
+	c := &FastHTTPCli{
+		serviceName: name,
+		client:      client.DefaultClient,
+	}
+	c.opts = make([]client.Option, 0, len(opts)+1)
+	c.opts = append(c.opts, client.WithProtocol(fastHTTPProtocol))
+	c.opts = append(c.opts, opts...)
+	return c
+}
+
+// NewFastHTTPClient returns fasthttp.Client of the go sdk, which is convenient
+// for third-party clients to use, and can report monitoring metrics.
+// After returning, user can configure the fasthttp.Client.
+// User can configure the fasthttp.HostClient by modifying field `ConfigureClient`
+// It is recommended to use fasthttp.Client.Do(req, rsp) for making requests.
+// Notice: name should NOT be "".
+func NewFastHTTPClient(name string, opts ...client.Option) *fasthttp.Client {
+	c := &FastHTTPCli{
+		serviceName: name,
+		client:      client.DefaultClient,
+	}
+	c.opts = make([]client.Option, 0, len(opts)+2)
+	c.opts = append(c.opts, client.WithProtocol(fastHTTPProtocol))
+	c.opts = append(c.opts, opts...)
+	// Use passthrough selector to bypass the naming process,
+	// as the framework will ignore the result of naming.
+	// Ensure it takes effect by placing it afterwards.
+	c.opts = append(c.opts, client.WithTarget("passthrough://"+name))
+	return &fasthttp.Client{
+		ConfigureClient: func(hc *fasthttp.HostClient) error {
+			hc.Transport = func(req *fasthttp.Request, rsp *fasthttp.Response) error {
+				_, err := c.RoundTrip(hc, req, rsp)
+				return err
+			}
+			return nil
+		},
+	}
+}
+
+// RoundTrip implements the fasthttp.RoundTripper interface for fastHTTPCli.
+// Notice: Calls through FastHTTPClientProxy do NOT go through RoundTrip.
+// Currently, retries are always returned false in RoundTrip.
+func (c *FastHTTPCli) RoundTrip(
+	hc *fasthttp.HostClient,
+	req *fasthttp.Request,
+	rsp *fasthttp.Response,
+) (retry bool, err error) {
+	ctx, msg := codec.WithCloneMessage(context.Background())
+	defer codec.PutBackMessage(msg)
+
+	c.setDefaultCallOption(msg, string(req.URI().Path()))
+	// Align with thttp.
+	msg.WithClientReqHead(&FastHTTPClientReqHeader{
+		Scheme:  string(req.URI().Scheme()),
+		Method:  string(req.Header.Method()),
+		Host:    string(req.Host()),
+		Request: req,
+	})
+	msg.WithClientRspHead(&FastHTTPClientRspHeader{Response: rsp})
+
+	if err := c.client.Invoke(ctx, nil, nil, c.opts...); err != nil {
+		// If the error is caused by the status code, ignore it and return the response normally.
+		if rsp != nil && rsp.StatusCode() == int(errs.Code(err)) {
+			return false, nil
+		}
+		return false, err
+	}
+	return false, nil
+}
+
+// setDefaultCallOption sets default call option.
+func (c *FastHTTPCli) setDefaultCallOption(msg codec.Msg, path string) {
+	msg.WithClientRPCName(path)
+	msg.WithCalleeServiceName(c.serviceName)
+	msg.WithSerializationType(codec.SerializationTypeJSON)
+
+	// Callee method is mainly for metrics.
+	// User can copy this part of code and modify it yourself to meet special requirements.
+	if s := strings.Split(path, "?"); len(s) > 0 {
+		msg.WithCalleeMethod(s[0])
+	}
+}
+
+// Get uses trpc client to send fasthttp GET request.
+// Param path represents the url segments that follow domain, e.g. /cgi-bin/get_xxx?k1=v1&k2=v2.
+// Param reqBody and rspBody are passed in with specific type,
+// corresponding serialization should be specified, or json by default.
+// msg.WithClientReqHead will be called within this method to ensure that Method is GET.
+func (c *FastHTTPCli) Get(ctx context.Context, path string, rspBody interface{}, opts ...client.Option) error {
+	ctx, msg := codec.WithCloneMessage(ctx)
+	defer codec.PutBackMessage(msg)
+	c.setDefaultCallOption(msg, path)
+	msg.WithClientReqHead(&FastHTTPClientReqHeader{Method: fasthttp.MethodGet})
+	return c.send(ctx, nil, rspBody, opts...)
+}
+
+// Post uses trpc client to send fasthttp POST request.
+// Param path represents the url segments that follow domain, e.g. /cgi-bin/add_xxx.
+// Param rspBody and rspBody are passed in with specific type,
+// corresponding serialization should be specified, or json by default.
+// msg.WithClientReqHead will be called within this method to ensure that Method is POST.
+func (c *FastHTTPCli) Post(ctx context.Context, path string, reqBody interface{}, rspBody interface{},
+	opts ...client.Option) error {
+	ctx, msg := codec.WithCloneMessage(ctx)
+	defer codec.PutBackMessage(msg)
+	c.setDefaultCallOption(msg, path)
+	msg.WithClientReqHead(&FastHTTPClientReqHeader{Method: fasthttp.MethodPost})
+	return c.send(ctx, reqBody, rspBody, opts...)
+}
+
+// Put uses trpc client to send fasthttp PUT request.
+// Param path represents the url segments that follow domain, e.g. /cgi-bin/update_xxx.
+// Param rspBody and rspBody are passed in with specific type,
+// corresponding serialization should be specified, or json by default.
+// msg.WithClientReqHead will be called within this method to ensure that Method is PUT.
+func (c *FastHTTPCli) Put(ctx context.Context, path string, reqBody interface{}, rspBody interface{},
+	opts ...client.Option) error {
+	ctx, msg := codec.WithCloneMessage(ctx)
+	defer codec.PutBackMessage(msg)
+	c.setDefaultCallOption(msg, path)
+	msg.WithClientReqHead(&FastHTTPClientReqHeader{Method: fasthttp.MethodPut})
+	return c.send(ctx, reqBody, rspBody, opts...)
+}
+
+// Patch uses trpc client to send fasthttp PATCH request.
+// Param path represents the url segments that follow domain, e.g. /cgi-bin/update_xxx.
+// Param rspBody and rspBody are passed in with specific type,
+// corresponding serialization should be specified, or json by default.
+// msg.WithClientReqHead will be called within this method to ensure that Method is PATCH.
+func (c *FastHTTPCli) Patch(ctx context.Context, path string, reqBody interface{}, rspBody interface{},
+	opts ...client.Option) error {
+	ctx, msg := codec.WithCloneMessage(ctx)
+	defer codec.PutBackMessage(msg)
+	c.setDefaultCallOption(msg, path)
+	msg.WithClientReqHead(&FastHTTPClientReqHeader{Method: fasthttp.MethodPatch})
+	return c.send(ctx, reqBody, rspBody, opts...)
+}
+
+// Delete uses trpc client to send fasthttp DELETE request.
+// Param path represents the url segments that follow domain, e.g. /cgi-bin/delete_xxx.
+// Param reqBody and rspBody are passed in with specific type,
+// corresponding serialization should be specified, or json by default.
+// msg.WithClientReqHead will be called within this method to ensure that Method is DELETE.
+//
+// Delete may have body, if it is empty, set reqBody and rspBody with nil.
+func (c *FastHTTPCli) Delete(ctx context.Context, path string, reqBody interface{}, rspBody interface{},
+	opts ...client.Option) error {
+	ctx, msg := codec.WithCloneMessage(ctx)
+	defer codec.PutBackMessage(msg)
+	c.setDefaultCallOption(msg, path)
+	msg.WithClientReqHead(&FastHTTPClientReqHeader{Method: fasthttp.MethodDelete})
+	return c.send(ctx, reqBody, rspBody, opts...)
+}
+
+// send uses client (protocol: fasthttp) to send fasthttp request.
+func (c *FastHTTPCli) send(ctx context.Context, reqBody, rspBody interface{}, opts ...client.Option) error {
+	options := make([]client.Option, 0, len(c.opts)+len(opts))
+	options = append(options, c.opts...)
+	options = append(options, opts...)
+	return c.client.Invoke(ctx, reqBody, rspBody, options...)
+}

--- a/http/fasthttp_client_test.go
+++ b/http/fasthttp_client_test.go
@@ -1,0 +1,110 @@
+//
+//
+// Tencent is pleased to support the open source community by making tRPC available.
+//
+// Copyright (C) 2023 Tencent.
+// All rights reserved.
+//
+// If you have downloaded a copy of the tRPC source code from Tencent,
+// please note that tRPC source code is licensed under the  Apache 2.0 License,
+// A copy of the Apache 2.0 License is included in this file.
+//
+//
+
+package http_test
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/valyala/fasthttp"
+
+	"trpc.group/trpc-go/trpc-go/client"
+	"trpc.group/trpc-go/trpc-go/codec"
+	thttp "trpc.group/trpc-go/trpc-go/http"
+)
+
+func TestFastHTTPClientStdServer(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPut {
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte("unsupported method"))
+			return
+		}
+		_, _ = io.Copy(w, r.Body)
+	}))
+	defer ts.Close()
+
+	fc := thttp.NewFastHTTPClient("trpc.fasthttp.client.test")
+
+	status, body, err := fc.Get(nil, ts.URL)
+	require.NoError(t, err)
+	require.Equal(t, fasthttp.StatusOK, status)
+	require.Empty(t, body)
+
+	req := fasthttp.AcquireRequest()
+	rsp := fasthttp.AcquireResponse()
+	defer fasthttp.ReleaseRequest(req)
+	defer fasthttp.ReleaseResponse(rsp)
+	req.Header.SetMethod(fasthttp.MethodPost)
+	req.Header.SetContentType("application/json")
+	req.Header.SetRequestURI(ts.URL)
+	req.SetBodyString(`{"name":"trpc"}`)
+	require.NoError(t, fc.Do(req, rsp))
+	require.Equal(t, fasthttp.StatusOK, rsp.StatusCode())
+	require.Equal(t, `{"name":"trpc"}`, string(rsp.Body()))
+
+	req.Reset()
+	rsp.Reset()
+	req.Header.SetMethod(fasthttp.MethodPut)
+	req.SetRequestURI(ts.URL)
+	require.NoError(t, fc.Do(req, rsp))
+	require.Equal(t, fasthttp.StatusInternalServerError, rsp.StatusCode())
+	require.Equal(t, "unsupported method", string(rsp.Body()))
+}
+
+func TestFastHTTPClientProxyStdServer(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPut {
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte("unsupported method"))
+			return
+		}
+		_, _ = io.Copy(w, r.Body)
+	}))
+	defer ts.Close()
+
+	target := strings.Replace(ts.URL, "http", "ip", 1)
+	fcp := thttp.NewFastHTTPClientProxy("trpc.fasthttp.client.test", client.WithTarget(target))
+	reqBody := &codec.Body{}
+	rspBody := &codec.Body{}
+
+	require.NoError(t, fcp.Get(context.Background(), "", rspBody))
+	require.Nil(t, rspBody.Data)
+
+	reqBody.Data = []byte(`{"name":"trpc"}`)
+	require.NoError(t, fcp.Post(context.Background(), "", reqBody, rspBody))
+	require.Equal(t, reqBody.Data, rspBody.Data)
+
+	rspBody.Data = nil
+	require.Error(t, fcp.Put(context.Background(), "", reqBody, rspBody))
+
+	rspBody.Data = nil
+	require.NoError(t, fcp.Patch(context.Background(), "", reqBody, rspBody))
+	require.Equal(t, reqBody.Data, rspBody.Data)
+
+	rspBody.Data = nil
+	require.NoError(t, fcp.Delete(context.Background(), "", reqBody, rspBody))
+	require.Equal(t, reqBody.Data, rspBody.Data)
+}
+
+func TestFastHTTPPassThroughError(t *testing.T) {
+	c := thttp.NewFastHTTPClient("trpc.fasthttp.client.test", client.WithTarget("ip://127.0.0.1:1"))
+	_, _, err := c.Get(nil, "http://127.0.0.1:1")
+	require.Error(t, err)
+}

--- a/http/fasthttp_codec.go
+++ b/http/fasthttp_codec.go
@@ -1,0 +1,693 @@
+//
+//
+// Tencent is pleased to support the open source community by making tRPC available.
+//
+// Copyright (C) 2023 Tencent.
+// All rights reserved.
+//
+// If you have downloaded a copy of the tRPC source code from Tencent,
+// please note that tRPC source code is licensed under the  Apache 2.0 License,
+// A copy of the Apache 2.0 License is included in this file.
+//
+//
+
+package http
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"os"
+	"path"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/valyala/fasthttp"
+	trpcpb "trpc.group/trpc/trpc-protocol/pb/go/trpc"
+
+	"trpc.group/trpc-go/trpc-go/codec"
+	"trpc.group/trpc-go/trpc-go/errs"
+	icodec "trpc.group/trpc-go/trpc-go/internal/codec"
+)
+
+func init() {
+	codec.Register(fastHTTPProtocol, DefaultFastHTTPServerCodec, DefaultFastHTTPClientCodec)
+	codec.Register(fastHTTPNoProtocolProtocol, DefaultFastHTTPNoProtocolServerCodec, DefaultFastHTTPClientCodec)
+}
+
+var (
+	// DefaultFastHTTPClientCodec is the default fasthttp client side codec.
+	DefaultFastHTTPClientCodec = &FastHTTPClientCodec{}
+
+	// DefaultFastHTTPServerCodec is the default fasthttp server side codec.
+	DefaultFastHTTPServerCodec = &FastHTTPServerCodec{
+		AutoGenTrpcHead:              true,
+		ErrHandler:                   defaultFastHTTPErrHandler,
+		RspHandler:                   defaultFastHTTPRspHandler,
+		AutoReadBody:                 true,
+		DisableEncodeTransInfoBase64: false,
+		POSTOnly:                     false,
+	}
+
+	// DefaultFastHTTPNoProtocolServerCodec is the default fasthttp_no_protocol server side codec.
+	DefaultFastHTTPNoProtocolServerCodec = &FastHTTPServerCodec{
+		AutoGenTrpcHead:              true,
+		ErrHandler:                   defaultFastHTTPErrHandler,
+		RspHandler:                   defaultFastHTTPRspHandler,
+		AutoReadBody:                 false,
+		DisableEncodeTransInfoBase64: false,
+		POSTOnly:                     false,
+	}
+)
+
+// ErrEncodeMissingRequestCtx defines error used for special handling
+// in transport when ctx lost lost requestCtx information.
+var ErrEncodeMissingRequestCtx = errors.New("trpc/fasthttp: server encode missing fasthttp requestCtx in context")
+
+// FastHTTPClientReqHeader encapsulates fasthttp client context.
+// Setting ClientReqHeader is not allowed when NewFastHTTPClientProxy is waiting for the init of Client.
+// FastHTTPClientReqHeader is needed for each RPC.
+type FastHTTPClientReqHeader struct {
+	Request *fasthttp.Request
+	Scheme  string // Examples: HTTP, HTTPS.
+	Method  string
+	// Host directly sets the final host field in the fasthttp.Request.
+	Host string
+	// DecorateRequest will be called right before client.DoRedirects(req, rsp, cnt) to
+	// allow users to make final custom modifications to the fasthttp request.
+	// Users can set the headers of req by configuring this field.
+	DecorateRequest func(*fasthttp.Request) *fasthttp.Request
+}
+
+// FastHTTPRspHandler is an interface for users to implement fasthttp response callbacks.
+type FastHTTPRspHandler interface {
+	// Handle handles fasthttp response.
+	// If the returned error is non-nil, the framework will
+	// abort the reading of the fasthttp connection.
+	Handle(*fasthttp.Response) error
+}
+
+// FastHTTPClientRspHeader encapsulates the context returned by fasthttp client response.
+type FastHTTPClientRspHeader struct {
+	Response *fasthttp.Response
+
+	// ManualReadBody is used to control whether to read fasthttp response manually
+	// (not read automatically by the framework).
+	// Set it to true so that user can read data directly from Response.Body manually.
+	// The default value is false.
+	ManualReadBody bool
+
+	// ResponseHandler is an interface that the framework will invoke
+	// if SSECondition returns false OR SSEHandler is not defined.
+	// If ResponseHandler is provided by the user, the framework will automatically
+	// read the fasthttp response body and invoke the ResponseHandler for each response.
+	ResponseHandler FastHTTPRspHandler
+
+	// SSECondition is a function that users must implement to determine
+	// whether to call server-sent event (SSE) message callbacks.
+	// If SSECondition returns true AND SSEHandler is defined, the framework will
+	// call the SSEHandler for each SSE event in sequence.
+	SSECondition func(*fasthttp.Response) bool
+
+	// SSEHandler is an interface that users must implement to handle
+	// server-sent event (SSE) message callbacks.
+	// When this field is provided by the user, the framework will automatically
+	// add the following headers to the request, if they are not already present:
+	//
+	//  "Accept": "text/event-stream"
+	//  "Connection": "keep-alive"
+	//  "Cache-Control": "no-cache"
+	//
+	// The framework will automatically parse the fasthttp response into SSE events
+	// and invoke the SSEHandler for each SSE event in sequence.
+	// If any SSEHandler returns an error, the process will be halted and the
+	// error will be returned.
+	// The parsing of SSE events will continue until an io.EOF is encountered
+	// in the reading of the fasthttp response body.
+	SSEHandler SSEHandler
+}
+
+// FastHTTPServerCodec is the encoder/decoder for fasthttp server.
+type FastHTTPServerCodec struct {
+	// AutoGenTrpcHead converts trpc header automatically.
+	// Auto conversion could be enabled by setting AutoGenTrpcHead true.
+	// DefaultFastHTTPServerCodec.AutoGenTrpcHead is true.
+	// DefaultFastHTTPNoProtocolServerCodec.AutoGenTrpcHead is true.
+	AutoGenTrpcHead bool
+
+	// ErrHandler is error code handle function, which is filled into header by default.
+	// Business can set this with ErrHandler = func(requestCtx, err) {}.
+	ErrHandler FastHTTPErrorHandler
+
+	// RspHandler returns the data handle function. By default, data is returned directly.
+	// Business can set this with RspHandler = func(requestCtx, rspBody) {}
+	// to shape returned data.
+	RspHandler FastHTTPResponseHandler
+
+	// AutoReadBody reads fasthttp request body automatically.
+	// DefaultFastHTTPServerCodec.AutoReadBody is true.
+	// DefaultFastHTTPNoProtocolServerCodec.AutoReadBody is false.
+	AutoReadBody bool
+
+	// DisableEncodeTransInfoBase64 indicates whether to disable encoding the transinfo value by base64.
+	// DefaultFastHTTPServerCodec.DisableEncodeTransInfoBase64 is false.
+	// DefaultFastHTTPNoProtocolServerCodec.DisableEncodeTransInfoBase64 is false.
+	DisableEncodeTransInfoBase64 bool
+
+	// POSTOnly determines whether to process only requests that use the POST method.
+	// This is commonly used in an FastHTTP RPC server to allow only the POST method to be accepted,
+	// instead of allowing both the POST and GET methods.
+	// DefaultFastHTTPServerCodec.POSTOnly is false.
+	// DefaultFastHTTPNoProtocolServerCodec.POSTOnly is false.
+	POSTOnly bool
+}
+
+// FastHTTPErrorHandler handles error of fasthttp server's response.
+// By default, the error code is placed in header,
+// which can be replaced by a specific implementation of user.
+type FastHTTPErrorHandler func(requestCtx *fasthttp.RequestCtx, e *errs.Error)
+
+var defaultFastHTTPErrHandler = func(requestCtx *fasthttp.RequestCtx, e *errs.Error) {
+	// Replace(-1) may be better than ReplaceAll.
+	errMsg := strings.Replace(e.Msg, "\r", "\\r", -1)
+	errMsg = strings.Replace(errMsg, "\n", "\\n", -1)
+
+	requestCtx.Response.Header.Add(canonicalTrpcErrorMessage, errMsg)
+	if e.Type == errs.ErrorTypeFramework {
+		requestCtx.Response.Header.Add(canonicalTrpcFrameworkErrorCode, strconv.Itoa(int(e.Code)))
+	} else {
+		requestCtx.Response.Header.Add(canonicalTrpcUserFuncErrorCode, strconv.Itoa(int(e.Code)))
+	}
+	if code, ok := ErrsToHTTPStatus[e.Code]; ok {
+		requestCtx.SetStatusCode(code)
+	}
+}
+
+// FastHTTPResponseHandler handles data of fasthttp server's response.
+// By default, the content is returned directly,
+// which can be replaced by a specific implementation of user.
+type FastHTTPResponseHandler func(requestCtx *fasthttp.RequestCtx, rspBody []byte) error
+
+var defaultFastHTTPRspHandler = func(requestCtx *fasthttp.RequestCtx, rspBody []byte) error {
+	if len(rspBody) != 0 {
+		// SetBodyRaw sets response body, but without copying it.
+		// From this point onward the body argument must not be changed.
+		// User can define their own FastHTTPResponseHandler with SetBody() or SetBodyStream() or anything else.
+		requestCtx.Response.SetBodyRaw(rspBody)
+	}
+	return nil
+}
+
+// handleContentTypeForCompatibility is used to address the inconsistency in the behavior
+// of the ContentType header in the response (rsp) between fasthttp and net/http.
+// For response headers, the ContentType logic differs between http and fasthttp,
+// http defaults to returning "", while fasthttp defaults to return []byte("text/plain; charset=utf-8").
+// Strangely, for request headers, both are consistent, returning "".
+func handleContentTypeForCompatibility(req *fasthttp.Request, rsp *fasthttp.Response) {
+	const defaultRspContentTypeForHTTP = ""
+	const defaultRspContentTypeForFastHTTP = "text/plain; charset=utf-8"
+	ct := string(rsp.Header.Peek(canonicalContentType))
+	if ct == defaultRspContentTypeForFastHTTP {
+		ct = string(req.Header.Peek(canonicalContentType))
+		if string(req.Header.Method()) == fasthttp.MethodGet || ct == "" {
+			ct = "application/json"
+		}
+		rsp.Header.Add(canonicalContentType, ct)
+	}
+	// The Content-Type header may contain additional information besides
+	// the MIME type, such as character set encoding.
+	// Direct comparison using equal may fail due to these additional details.
+	if strings.Contains(ct, serializationTypeContentType[codec.SerializationTypeFormData]) {
+		formDataCt := getFormDataContentType()
+		rsp.Header.Set(canonicalContentType, formDataCt)
+	}
+}
+
+// Encode packs the body into binary buffer.
+// It implements codec.Codec interface for FastHTTPServerCodec.
+// server: Encode(msg, rspBody) (rspBuffer, err)
+func (sc *FastHTTPServerCodec) Encode(msg codec.Msg, rspBody []byte) ([]byte, error) {
+	requestCtx := RequestCtx(msg.Context())
+	if requestCtx == nil {
+		return nil, ErrEncodeMissingRequestCtx
+	}
+
+	req := &requestCtx.Request
+	rsp := &requestCtx.Response
+
+	// nosniff is a security-related response header used to prevent browsers from MIME type sniffing,
+	// thereby reducing the risk of cross-site scripting attacks and content injection attacks.
+	// By setting this header, the security of the application can be enhanced.
+	rsp.Header.Add(canonicalXContentTypeOptions, "nosniff")
+
+	// For response headers, the ContentType logic differs between http and fasthttp,
+	// use handleContentTypeForCompatibility to handle difference.
+	handleContentTypeForCompatibility(req, rsp)
+
+	// Return packet tells client to use which decompress method.
+	if t := msg.CompressType(); icodec.IsValidCompressType(t) && t != codec.CompressTypeNoop {
+		rsp.Header.Set(canonicalContentEncoding, compressTypeContentEncoding[t])
+	}
+
+	if len(msg.ServerMetaData()) > 0 {
+		m := make(map[string]string)
+		if sc.DisableEncodeTransInfoBase64 {
+			for k, v := range msg.ServerMetaData() {
+				m[k] = string(v)
+			}
+		} else {
+			for k, v := range msg.ServerMetaData() {
+				m[k] = base64.StdEncoding.EncodeToString(v)
+			}
+		}
+		val, err := codec.Marshal(codec.SerializationTypeJSON, m)
+		if err != nil {
+			return nil, err
+		}
+		rsp.Header.SetBytesV(canonicalTrpcTransInfo, val)
+	}
+
+	// 1. Handle exceptions first, as long as server returns an error,
+	// the returned data will no longer be processed.
+	if e := msg.ServerRspErr(); e != nil {
+		if sc.ErrHandler != nil {
+			sc.ErrHandler(requestCtx, e)
+		}
+		return nil, nil
+	}
+
+	// 2. process returned data under normal case.
+	if sc.RspHandler != nil {
+		if err := sc.RspHandler(requestCtx, rspBody); err != nil {
+			return nil, err
+		}
+	}
+
+	return nil, nil
+}
+
+// Decode unpacks the body from binary buffer.
+// It implements codec.Codec interface for FastHTTPServerCodec.
+// server: Decode(msg, reqBuffer) (reqBody, err)
+func (sc *FastHTTPServerCodec) Decode(msg codec.Msg, _ []byte) ([]byte, error) {
+	requestCtx := RequestCtx(msg.Context())
+	if requestCtx == nil {
+		return nil, errors.New("server decode missing fasthttp requestCtx in context")
+	}
+
+	msg.WithCalleeMethod(string(requestCtx.Path()))
+	msg.WithServerRPCName(string(requestCtx.Path()))
+
+	reqBody, err := sc.getReqBody(requestCtx, msg)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := sc.setReqHeader(requestCtx, msg); err != nil {
+		return nil, err
+	}
+
+	sc.updateMsg(requestCtx, msg)
+	return reqBody, nil
+}
+
+// getReqBody gets the body of request and update the msg.
+func (sc *FastHTTPServerCodec) getReqBody(
+	requestCtx *fasthttp.RequestCtx,
+	msg codec.Msg,
+) ([]byte, error) {
+	if !sc.AutoReadBody {
+		return nil, nil
+	}
+
+	if sc.POSTOnly && string(requestCtx.Method()) != fasthttp.MethodPost {
+		return nil, fmt.Errorf("server codec only allows POST method request, the current method is %s",
+			string(requestCtx.Method()))
+	}
+
+	// The reqBody for GET is the QueryArgs.
+	if string(requestCtx.Method()) == fasthttp.MethodGet {
+		msg.WithSerializationType(codec.SerializationTypeGet)
+		return requestCtx.URI().QueryString(), nil
+	}
+
+	// SerializationType is JSON by default.
+	msg.WithSerializationType(codec.SerializationTypeJSON)
+	ct := string(requestCtx.Request.Header.Peek(canonicalContentType))
+	for contentType, serializationType := range contentTypeSerializationType {
+		if !strings.Contains(ct, contentType) {
+			continue
+		}
+		msg.WithSerializationType(serializationType)
+		return getBodyForFastHTTP(ct, requestCtx)
+	}
+
+	return nil, nil
+}
+
+// getBodyForFastHTTP handles FormData specially,
+// while for others it directly returns requestCtx.Request.Body().
+func getBodyForFastHTTP(ct string, requestCtx *fasthttp.RequestCtx) ([]byte, error) {
+	if !strings.Contains(ct, serializationTypeContentType[codec.SerializationTypeFormData]) {
+		return requestCtx.Request.Body(), nil
+	}
+
+	// Fail fast.
+	multipartForm, err := requestCtx.MultipartForm()
+	if err != nil {
+		return nil, err
+	}
+
+	// Acquire Args is for simplicity rather than efficiency.
+	// Directly call args.QueryString() instead of handling it manually.
+	args := fasthttp.AcquireArgs()
+	defer fasthttp.ReleaseArgs(args)
+
+	requestCtx.QueryArgs().VisitAll(func(key, value []byte) {
+		args.AddBytesKV(key, value)
+	})
+
+	requestCtx.PostArgs().VisitAll(func(key, value []byte) {
+		args.AddBytesKV(key, value)
+	})
+
+	for k, vs := range multipartForm.Value {
+		for _, v := range vs {
+			args.Add(k, v)
+		}
+	}
+
+	return args.QueryString(), nil
+}
+
+// setReqHeader sets ServerReqHead according to the relative trpc-field in requestCtx.
+func (sc *FastHTTPServerCodec) setReqHeader(requestCtx *fasthttp.RequestCtx, msg codec.Msg) error {
+	// Auto generates trpc head is disabled, just return nil.
+	if !sc.AutoGenTrpcHead {
+		return nil
+	}
+
+	trpcReq := &trpcpb.RequestProtocol{}
+	msg.WithServerReqHead(trpcReq)
+
+	trpcReq.Func = []byte(msg.ServerRPCName())
+	contentType, err := intToUint32(msg.SerializationType(), "serialization type")
+	if err != nil {
+		return err
+	}
+	trpcReq.ContentType = contentType
+	contentEncoding, err := intToUint32(msg.CompressType(), "compression type")
+	if err != nil {
+		return err
+	}
+	trpcReq.ContentEncoding = contentEncoding
+
+	req := &requestCtx.Request
+	if v := string(req.Header.Peek(canonicalTrpcVersion)); v != "" {
+		version, err := parseUint32Header(v, canonicalTrpcVersion)
+		if err != nil {
+			return err
+		}
+		trpcReq.Version = version
+	}
+
+	if v := string(req.Header.Peek(canonicalTrpcCallType)); v != "" {
+		callType, err := parseUint32Header(v, canonicalTrpcCallType)
+		if err != nil {
+			return err
+		}
+		trpcReq.CallType = callType
+	}
+
+	if v := string(req.Header.Peek(canonicalTrpcMessageType)); v != "" {
+		messageType, err := parseUint32Header(v, canonicalTrpcMessageType)
+		if err != nil {
+			return err
+		}
+		trpcReq.MessageType = messageType
+	}
+
+	if v := string(req.Header.Peek(canonicalTrpcRequestID)); v != "" {
+		requestId, err := parseUint32Header(v, canonicalTrpcRequestID)
+		if err != nil {
+			return err
+		}
+		trpcReq.RequestId = requestId
+	}
+
+	if v := string(req.Header.Peek(canonicalTrpcTimeout)); v != "" {
+		timeout, err := parseUint32Header(v, canonicalTrpcTimeout)
+		if err != nil {
+			return err
+		}
+		trpcReq.Timeout = timeout
+		msg.WithRequestTimeout(time.Millisecond * time.Duration(timeout))
+	}
+
+	if method := string(req.Header.Peek(canonicalTrpcCallerMethod)); method != "" {
+		msg.WithCallerMethod(method)
+	}
+
+	if caller := req.Header.Peek(canonicalTrpcCaller); len(caller) != 0 {
+		trpcReq.Caller = caller
+		msg.WithCallerServiceName(string(caller))
+	}
+
+	if callee := req.Header.Peek(canonicalTrpcCallee); len(callee) != 0 {
+		trpcReq.Callee = callee
+		msg.WithCalleeServiceName(string(callee))
+	}
+
+	msg.WithDyeing((trpcReq.GetMessageType() & uint32(trpcpb.TrpcMessageType_TRPC_DYEING_MESSAGE)) != 0)
+
+	if v := string(req.Header.Peek(canonicalTrpcTransInfo)); v != "" {
+		transInfo, err := unmarshalTransInfo(msg, v)
+		if err != nil {
+			return err
+		}
+		trpcReq.TransInfo = transInfo
+	}
+	msg.WithServerRspHead(newResponseProtocol(trpcReq))
+	return nil
+}
+
+func parseUint32Header(v, key string) (uint32, error) {
+	n, err := strconv.ParseUint(v, 10, 32)
+	if err != nil {
+		return 0, fmt.Errorf("invalid %s header %q: %w", key, v, err)
+	}
+	// strconv.ParseUint with bitSize 32 has already range-checked the value.
+	//nolint:gosec
+	return uint32(n), nil
+}
+
+func intToUint32(v int, name string) (uint32, error) {
+	const maxUint32 = 1<<32 - 1
+	if v < 0 || uint64(v) > maxUint32 {
+		return 0, fmt.Errorf("%s out of uint32 range: %d", name, v)
+	}
+	// The bounds check above guarantees that v fits in uint32.
+	//nolint:gosec
+	return uint32(v), nil
+}
+
+// updateMsg updates msg according to requestCtx.
+func (sc *FastHTTPServerCodec) updateMsg(requestCtx *fasthttp.RequestCtx, msg codec.Msg) {
+	req := &requestCtx.Request
+	if v := string(req.Header.Peek(canonicalContentEncoding)); v != "" {
+		msg.WithCompressType(contentEncodingCompressType[v])
+	}
+
+	if msg.CallerServiceName() == "" {
+		msg.WithCallerServiceName("trpc.fasthttp.upserver.upservice")
+	}
+
+	if msg.CalleeServiceName() == "" {
+		msg.WithCalleeServiceName(fmt.Sprintf("trpc.fasthttp.%s.service", path.Base(os.Args[0])))
+	}
+}
+
+// FastHTTPClientCodec is the fasthttp client side codec.
+type FastHTTPClientCodec struct {
+	// ErrHandler is error code handle function, which is filled into header by default. Business can
+	// set this with thttp.DefaultFastHTTPClientCodec.ErrHandler = func(rsp, msg, body) ([]byte, error) {}.
+	ErrHandler FastHTTPDecodeErrorHandler
+}
+
+// Encode sets metadata requested by fasthttp client and packs the body into binary buffer.
+// Client has been serialized and passed to reqBody with compress.
+// It implements codec.Codec interface for FastHTTPClientCodec.
+// client: Encode(msg, reqBody)(request-buffer, err)
+func (c *FastHTTPClientCodec) Encode(msg codec.Msg, reqBody []byte) ([]byte, error) {
+	var reqHeader *FastHTTPClientReqHeader
+	if h := msg.ClientReqHead(); h != nil {
+		fastHTTPReqHeader, ok := h.(*FastHTTPClientReqHeader)
+		if !ok {
+			return nil, fmt.Errorf("fasthttp header must be type of *FastHTTPClientReqHeader, current type: %T", h)
+		}
+		reqHeader = fastHTTPReqHeader
+	} else {
+		reqHeader = &FastHTTPClientReqHeader{}
+		msg.WithClientReqHead(reqHeader)
+	}
+
+	if h := msg.ClientRspHead(); h != nil {
+		if _, ok := h.(*FastHTTPClientRspHeader); !ok {
+			return nil, fmt.Errorf("fasthttp header must be type of *FastHTTPClientRspHeader, current type: %T", h)
+		}
+	} else {
+		msg.WithClientRspHead(&FastHTTPClientRspHeader{})
+	}
+
+	// Align with thttp.
+	if reqHeader.Method == "" {
+		if len(reqBody) == 0 {
+			reqHeader.Method = fasthttp.MethodGet
+		} else {
+			reqHeader.Method = fasthttp.MethodPost
+		}
+	}
+
+	if msg.CallerServiceName() == "" {
+		msg.WithCallerServiceName(fmt.Sprintf("trpc.fasthttp.%s.service", path.Base(os.Args[0])))
+	}
+
+	return reqBody, nil
+}
+
+// FastHTTPDecodeErrorHandler is used to handle error in FastHTTPClientCodec.Decode()
+type FastHTTPDecodeErrorHandler func(rsp *fasthttp.Response, msg codec.Msg, body []byte) ([]byte, error)
+
+var defaultFastHTTPDecodeErrHandler = func(rsp *fasthttp.Response, msg codec.Msg, body []byte) ([]byte, error) {
+	if fec := string(rsp.Header.Peek(canonicalTrpcFrameworkErrorCode)); fec != "" {
+		frameworkErrcode, err := strconv.Atoi(fec)
+		if err != nil {
+			return nil, err
+		}
+		if frameworkErrcode != 0 {
+			msg.WithClientRspErr(errs.NewFrameError(
+				trpcpb.TrpcRetCode(frameworkErrcode),
+				string(rsp.Header.Peek(canonicalTrpcErrorMessage)),
+			))
+			return nil, nil
+		}
+	}
+
+	if uec := string(rsp.Header.Peek(canonicalTrpcUserFuncErrorCode)); uec != "" {
+		userFuncErrcode, err := strconv.Atoi(uec)
+		if err != nil {
+			return nil, err
+		}
+		if userFuncErrcode != 0 {
+			msg.WithClientRspErr(
+				errs.New(
+					userFuncErrcode,
+					string(rsp.Header.Peek(canonicalTrpcErrorMessage)),
+				),
+			)
+			return nil, nil
+		}
+	}
+
+	// If rsp.StatusCode() >= 300, tfasthttp will invoke msg.WithClientRspErr.
+	// Align with thttp.
+	if rsp.StatusCode() >= fasthttp.StatusMultipleChoices {
+		msg.WithClientRspErr(
+			errs.New(rsp.StatusCode(), fmt.Sprintf("fasthttp client codec StatusCode: %s, body: %q",
+				fasthttp.StatusMessage(rsp.StatusCode()), rsp.Body()),
+			),
+		)
+		return nil, nil
+	}
+	return body, nil
+}
+
+// Decode unpacks the body from binary buffer and parses metadata in fasthttp response.
+// It implements codec.Codec interface for FastHTTPClientCodec.
+// client: Decode(msg, rspBuffer) (rspBody, err)
+func (c *FastHTTPClientCodec) Decode(msg codec.Msg, _ []byte) ([]byte, error) {
+	rspHeader, ok := msg.ClientRspHead().(*FastHTTPClientRspHeader)
+	if !ok {
+		return nil, fmt.Errorf("fasthttp header must be type of *fasthttp.ClientRspHeader, current type: %T", rspHeader)
+	}
+
+	body, err := handleFastHTTPResponseBody(rspHeader, msg)
+	if err != nil {
+		return nil, fmt.Errorf("handle response body: %w", err)
+	}
+
+	rsp := rspHeader.Response
+	if v := string(rsp.Header.Peek(canonicalContentEncoding)); v != "" {
+		msg.WithCompressType(contentEncodingCompressType[v])
+	}
+
+	if ct := string(rsp.Header.Peek(canonicalContentType)); ct != "" {
+		for contentType, serializationType := range contentTypeSerializationType {
+			if strings.Contains(ct, contentType) {
+				msg.WithSerializationType(serializationType)
+				break
+			}
+		}
+	}
+	if c.ErrHandler != nil {
+		return c.ErrHandler(rsp, msg, body)
+	}
+	return defaultFastHTTPDecodeErrHandler(rsp, msg, body)
+}
+
+// The default FastHTTPSSECondition always returns true.
+var defaultFastHTTPSSECondition = func(*fasthttp.Response) bool {
+	return true
+}
+
+// handleFastHTTPResponseBody process response body with different response types.
+func handleFastHTTPResponseBody(rspHeader *FastHTTPClientRspHeader, msg codec.Msg) ([]byte, error) {
+	rsp := rspHeader.Response
+	// Judge for ManualReadBody.
+	if len(rsp.Body()) == 0 || rspHeader.ManualReadBody {
+		return nil, nil
+	}
+
+	// If SSECondition is not implemented, set a default one.
+	if rspHeader.SSECondition == nil {
+		rspHeader.SSECondition = defaultFastHTTPSSECondition
+	}
+
+	// If SSECondition returns true and SSEHandler is implemented, process with it.
+	if rspHeader.SSECondition(rsp) && rspHeader.SSEHandler != nil {
+		// Handle SSE response with SSEHandler.
+		if err := handleSSE(bytes.NewReader(rsp.Body()), rspHeader.SSEHandler, msg); err != nil {
+			return nil, fmt.Errorf("handle sse error: %w", err)
+		}
+		return nil, nil
+	}
+
+	// Else if ResponseHandler is implemented, process with it.
+	if rspHeader.ResponseHandler != nil {
+		// Handle normal response with ResponseHandler.
+		if err := rspHeader.ResponseHandler.Handle(rsp); err != nil {
+			return nil, fmt.Errorf("handle response error: %w", err)
+		}
+		return nil, nil
+	}
+
+	return rsp.Body(), nil
+}
+
+type requestCtxKey struct{}
+
+// WithRequestCtx sets fasthttp requestCtx in context.
+func WithRequestCtx(ctx context.Context, requestCtx *fasthttp.RequestCtx) context.Context {
+	return context.WithValue(ctx, requestCtxKey{}, requestCtx)
+}
+
+// RequestCtx gets the corresponding fasthttp requestCtx from context.
+func RequestCtx(ctx context.Context) *fasthttp.RequestCtx {
+	if requestCtx, ok := ctx.Value(requestCtxKey{}).(*fasthttp.RequestCtx); ok {
+		return requestCtx
+	}
+	return nil
+}

--- a/http/fasthttp_codec_test.go
+++ b/http/fasthttp_codec_test.go
@@ -1,0 +1,349 @@
+//
+//
+// Tencent is pleased to support the open source community by making tRPC available.
+//
+// Copyright (C) 2023 Tencent.
+// All rights reserved.
+//
+// If you have downloaded a copy of the tRPC source code from Tencent,
+// please note that tRPC source code is licensed under the  Apache 2.0 License,
+// A copy of the Apache 2.0 License is included in this file.
+//
+//
+
+package http_test
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"mime/multipart"
+	"testing"
+	"time"
+
+	"github.com/r3labs/sse/v2"
+	"github.com/stretchr/testify/require"
+	"github.com/valyala/fasthttp"
+	trpcpb "trpc.group/trpc/trpc-protocol/pb/go/trpc"
+
+	"trpc.group/trpc-go/trpc-go/codec"
+	"trpc.group/trpc-go/trpc-go/errs"
+	thttp "trpc.group/trpc-go/trpc-go/http"
+)
+
+func TestFastHTTPServerEncode(t *testing.T) {
+	ctx := context.Background()
+	msg := codec.Message(ctx)
+	_, err := thttp.DefaultFastHTTPServerCodec.Encode(msg, nil)
+	require.Error(t, err)
+
+	requestCtx := &fasthttp.RequestCtx{}
+	ctx = thttp.WithRequestCtx(ctx, requestCtx)
+	msg = codec.Message(ctx)
+	msg.WithCompressType(codec.CompressTypeGzip)
+	_, err = thttp.DefaultFastHTTPServerCodec.Encode(msg, []byte("hello"))
+	require.NoError(t, err)
+	require.Equal(t, []byte("hello"), requestCtx.Response.Body())
+	require.Equal(t, "gzip", string(requestCtx.Response.Header.Peek(fasthttp.HeaderContentEncoding)))
+
+	requestCtx.Request.Reset()
+	requestCtx.Response.Reset()
+	msg = codec.Message(ctx)
+	msg.WithServerRspErr(errs.NewFrameError(1, "frame\r\nerror"))
+	_, err = thttp.DefaultFastHTTPServerCodec.Encode(msg, []byte("ignored"))
+	require.NoError(t, err)
+	require.Empty(t, requestCtx.Response.Body())
+	require.Equal(t, "frame\\r\\nerror", string(requestCtx.Response.Header.Peek(thttp.TrpcErrorMessage)))
+
+	requestCtx.Request.Reset()
+	requestCtx.Response.Reset()
+	msg = codec.Message(ctx)
+	msg.WithServerRspErr(errs.New(10086, "user error"))
+	_, err = thttp.DefaultFastHTTPServerCodec.Encode(msg, []byte("ignored"))
+	require.NoError(t, err)
+	require.Empty(t, requestCtx.Response.Body())
+	require.Equal(t, "10086", string(requestCtx.Response.Header.Peek(thttp.TrpcUserFuncErrorCode)))
+
+	requestCtx.Request.Reset()
+	requestCtx.Response.Reset()
+	requestCtx.Response.Header.SetContentType("multipart/form-data; boundary=test")
+	msg = codec.Message(ctx)
+	msg.WithServerMetaData(codec.MetaData{"meta-key": []byte("meta-value")})
+	sc := thttp.FastHTTPServerCodec{
+		AutoReadBody:                 true,
+		RspHandler:                   thttp.DefaultFastHTTPServerCodec.RspHandler,
+		DisableEncodeTransInfoBase64: true,
+	}
+	_, err = sc.Encode(msg, []byte("form"))
+	require.NoError(t, err)
+	require.Contains(t, string(requestCtx.Response.Header.Peek(thttp.TrpcTransInfo)), "meta-value")
+	require.Contains(t, string(requestCtx.Response.Header.ContentType()), "application/json")
+}
+
+func TestFastHTTPServerDecode(t *testing.T) {
+	ctx := context.Background()
+	msg := codec.Message(ctx)
+	_, err := thttp.DefaultFastHTTPServerCodec.Decode(msg, nil)
+	require.Error(t, err)
+
+	requestCtx := &fasthttp.RequestCtx{}
+	ctx = thttp.WithRequestCtx(ctx, requestCtx)
+	msg = codec.Message(ctx)
+	_, err = thttp.DefaultFastHTTPServerCodec.Decode(msg, nil)
+	require.NoError(t, err)
+
+	sc := thttp.FastHTTPServerCodec{AutoReadBody: true, POSTOnly: true}
+	requestCtx.Request.Reset()
+	requestCtx.Request.Header.SetMethod(fasthttp.MethodPatch)
+	msg = codec.Message(ctx)
+	_, err = sc.Decode(msg, nil)
+	require.Error(t, err)
+
+	requestCtx.Request.Reset()
+	requestCtx.Request.Header.SetMethod(fasthttp.MethodGet)
+	requestCtx.Request.SetRequestURI("http://example.com/path?k=v")
+	msg = codec.Message(ctx)
+	body, err := thttp.DefaultFastHTTPServerCodec.Decode(msg, nil)
+	require.NoError(t, err)
+	require.Equal(t, "k=v", string(body))
+	require.Equal(t, codec.SerializationTypeGet, msg.SerializationType())
+
+	requestCtx.Request.Reset()
+	requestCtx.Request.Header.SetMethod(fasthttp.MethodPost)
+	requestCtx.Request.Header.SetContentType("application/json")
+	requestCtx.Request.SetRequestURI("http://example.com/path")
+	requestCtx.Request.SetBodyString(`{"k":"v"}`)
+	msg = codec.Message(ctx)
+	body, err = thttp.DefaultFastHTTPServerCodec.Decode(msg, nil)
+	require.NoError(t, err)
+	require.Equal(t, `{"k":"v"}`, string(body))
+	require.Equal(t, codec.SerializationTypeJSON, msg.SerializationType())
+}
+
+func TestFastHTTPServerDecodeHeader(t *testing.T) {
+	requestCtx := &fasthttp.RequestCtx{}
+	ctx := thttp.WithRequestCtx(context.Background(), requestCtx)
+	msg := codec.Message(ctx)
+
+	req := &requestCtx.Request
+	req.Header.SetMethod(fasthttp.MethodPost)
+	req.SetRequestURI("http://example.com/trpc.http.test.helloworld/SayHello")
+	req.Header.Add(fasthttp.HeaderContentEncoding, "gzip")
+	req.Header.Add(fasthttp.HeaderContentType, "application/json")
+	req.Header.Add(thttp.TrpcVersion, "1")
+	req.Header.Add(thttp.TrpcCallType, "1")
+	req.Header.Add(thttp.TrpcMessageType, "1")
+	req.Header.Add(thttp.TrpcRequestID, "1")
+	req.Header.Add(thttp.TrpcTimeout, "1000")
+	req.Header.Add(thttp.TrpcCallerMethod, "CallerMethod")
+	req.Header.Add(thttp.TrpcCaller, "trpc.app.server.caller")
+	req.Header.Add(thttp.TrpcCallee, "trpc.http.test.helloworld")
+	req.Header.Add(thttp.TrpcTransInfo, `{"key1":"dmFsMQ==", "key2":"dmFsMg=="}`)
+
+	_, err := thttp.DefaultFastHTTPServerCodec.Decode(msg, nil)
+	require.NoError(t, err)
+	require.Equal(t, codec.CompressTypeGzip, msg.CompressType())
+	require.Equal(t, codec.SerializationTypeJSON, msg.SerializationType())
+	require.Equal(t, 1000*time.Millisecond, msg.RequestTimeout())
+	require.Equal(t, "CallerMethod", msg.CallerMethod())
+
+	rh, ok := msg.ServerReqHead().(*trpcpb.RequestProtocol)
+	require.True(t, ok)
+	require.Equal(t, uint32(1), rh.GetVersion())
+	require.Equal(t, uint32(1), rh.GetCallType())
+	require.Equal(t, uint32(1), rh.GetMessageType())
+	require.Equal(t, uint32(1), rh.GetRequestId())
+	require.Equal(t, uint32(1000), rh.GetTimeout())
+	require.Equal(t, "trpc.app.server.caller", string(rh.GetCaller()))
+	require.Equal(t, "trpc.http.test.helloworld", string(rh.GetCallee()))
+	require.Equal(t, "val1", string(rh.GetTransInfo()["key1"]))
+	require.Equal(t, "val2", string(rh.GetTransInfo()["key2"]))
+
+	req.Header.Set(thttp.TrpcTransInfo, `{"key1":"dmFsMQ==", "key2":"dmFsMg=="`)
+	_, err = thttp.DefaultFastHTTPServerCodec.Decode(msg, nil)
+	require.Error(t, err)
+
+	req.Header.Set(thttp.TrpcTransInfo, fmt.Sprintf(`{"%s":"%s"}`, thttp.TrpcEnv, "Production"))
+	_, err = thttp.DefaultFastHTTPServerCodec.Decode(msg, nil)
+	require.NoError(t, err)
+	rh, ok = msg.ServerReqHead().(*trpcpb.RequestProtocol)
+	require.True(t, ok)
+	require.Equal(t, "Production", string(rh.GetTransInfo()[thttp.TrpcEnv]))
+}
+
+func TestFastHTTPServerDecodeMultipartForm(t *testing.T) {
+	requestCtx := &fasthttp.RequestCtx{}
+	requestCtx.Request.Header.SetMethod(fasthttp.MethodPost)
+
+	uri := fasthttp.AcquireURI()
+	defer fasthttp.ReleaseURI(uri)
+	uri.SetScheme("http")
+	uri.SetHost("example.com")
+	uri.SetPath("/path")
+	uri.QueryArgs().Set("query", "value")
+	requestCtx.Request.SetURI(uri)
+	requestCtx.Request.PostArgs().Set("post", "value")
+
+	var buf bytes.Buffer
+	writer := multipart.NewWriter(&buf)
+	require.NoError(t, writer.WriteField("multipart", "value"))
+	fileWriter, err := writer.CreateFormFile("file", "example.txt")
+	require.NoError(t, err)
+	_, err = fileWriter.Write([]byte("file content"))
+	require.NoError(t, err)
+	require.NoError(t, writer.Close())
+
+	requestCtx.Request.Header.SetContentType(writer.FormDataContentType())
+	requestCtx.Request.SetBody(buf.Bytes())
+
+	ctx := thttp.WithRequestCtx(context.Background(), requestCtx)
+	msg := codec.Message(ctx)
+	body, err := thttp.DefaultFastHTTPServerCodec.Decode(msg, nil)
+	require.NoError(t, err)
+	require.Contains(t, string(body), "query=value")
+	require.Contains(t, string(body), "post=value")
+	require.Contains(t, string(body), "multipart=value")
+	require.Equal(t, codec.SerializationTypeFormData, msg.SerializationType())
+}
+
+func TestFastHTTPClientEncode(t *testing.T) {
+	_, msg := codec.WithNewMessage(context.Background())
+	_, err := thttp.DefaultFastHTTPClientCodec.Encode(msg, []byte(`{"name":"trpc"}`))
+	require.NoError(t, err)
+	require.IsType(t, &thttp.FastHTTPClientReqHeader{}, msg.ClientReqHead())
+	require.IsType(t, &thttp.FastHTTPClientRspHeader{}, msg.ClientRspHead())
+	require.Equal(t, fasthttp.MethodPost, msg.ClientReqHead().(*thttp.FastHTTPClientReqHeader).Method)
+
+	_, msg = codec.WithNewMessage(context.Background())
+	_, err = thttp.DefaultFastHTTPClientCodec.Encode(msg, nil)
+	require.NoError(t, err)
+	require.Equal(t, fasthttp.MethodGet, msg.ClientReqHead().(*thttp.FastHTTPClientReqHeader).Method)
+
+	_, msg = codec.WithNewMessage(context.Background())
+	msg.WithClientReqHead(&thttp.ClientReqHeader{})
+	_, err = thttp.DefaultFastHTTPClientCodec.Encode(msg, nil)
+	require.Error(t, err)
+
+	_, msg = codec.WithNewMessage(context.Background())
+	msg.WithClientRspHead(&thttp.ClientRspHeader{})
+	_, err = thttp.DefaultFastHTTPClientCodec.Encode(msg, nil)
+	require.Error(t, err)
+}
+
+func TestFastHTTPClientDecode(t *testing.T) {
+	rsp := fasthttp.AcquireResponse()
+	defer fasthttp.ReleaseResponse(rsp)
+	rsp.SetStatusCode(fasthttp.StatusOK)
+	rsp.Header.SetContentEncoding("gzip")
+	rsp.Header.SetContentType("application/json")
+	rsp.SetBodyString(`{"msg":"ok"}`)
+
+	_, msg := codec.WithNewMessage(context.Background())
+	msg.WithClientRspHead(&thttp.FastHTTPClientRspHeader{Response: rsp})
+	body, err := thttp.DefaultFastHTTPClientCodec.Decode(msg, nil)
+	require.NoError(t, err)
+	require.Equal(t, `{"msg":"ok"}`, string(body))
+	require.Equal(t, codec.CompressTypeGzip, msg.CompressType())
+	require.Equal(t, codec.SerializationTypeJSON, msg.SerializationType())
+}
+
+func TestFastHTTPClientDecodeErrors(t *testing.T) {
+	_, msg := codec.WithNewMessage(context.Background())
+	_, err := thttp.DefaultFastHTTPClientCodec.Decode(msg, nil)
+	require.Error(t, err)
+
+	_, msg = codec.WithNewMessage(context.Background())
+	msg.WithClientRspHead(&thttp.FastHTTPClientReqHeader{})
+	_, err = thttp.DefaultFastHTTPClientCodec.Decode(msg, nil)
+	require.Error(t, err)
+
+	rsp := fasthttp.AcquireResponse()
+	defer fasthttp.ReleaseResponse(rsp)
+
+	rsp.Reset()
+	rsp.SetStatusCode(fasthttp.StatusMultipleChoices)
+	_, msg = codec.WithNewMessage(context.Background())
+	msg.WithClientRspHead(&thttp.FastHTTPClientRspHeader{Response: rsp})
+	_, err = thttp.DefaultFastHTTPClientCodec.Decode(msg, nil)
+	require.NoError(t, err)
+	require.NotNil(t, msg.ClientRspErr())
+
+	rsp.Reset()
+	rsp.Header.Add(thttp.TrpcFrameworkErrorCode, "1")
+	rsp.Header.Add(thttp.TrpcErrorMessage, "frame error")
+	_, msg = codec.WithNewMessage(context.Background())
+	msg.WithClientRspHead(&thttp.FastHTTPClientRspHeader{Response: rsp})
+	_, err = thttp.DefaultFastHTTPClientCodec.Decode(msg, nil)
+	require.NoError(t, err)
+	require.Equal(t, trpcpb.TrpcRetCode(1), errs.Code(msg.ClientRspErr()))
+
+	rsp.Reset()
+	rsp.Header.Add(thttp.TrpcUserFuncErrorCode, "10086")
+	rsp.Header.Add(thttp.TrpcErrorMessage, "user error")
+	_, msg = codec.WithNewMessage(context.Background())
+	msg.WithClientRspHead(&thttp.FastHTTPClientRspHeader{Response: rsp})
+	_, err = thttp.DefaultFastHTTPClientCodec.Decode(msg, nil)
+	require.NoError(t, err)
+	require.Equal(t, trpcpb.TrpcRetCode(10086), errs.Code(msg.ClientRspErr()))
+}
+
+func TestFastHTTPClientDecodeHandlers(t *testing.T) {
+	rsp := fasthttp.AcquireResponse()
+	defer fasthttp.ReleaseResponse(rsp)
+
+	rsp.SetBodyString("data: hello\n\n")
+	_, msg := codec.WithNewMessage(context.Background())
+	msg.WithClientRspHead(&thttp.FastHTTPClientRspHeader{Response: rsp, SSEHandler: errSSEHandler{}})
+	_, err := thttp.DefaultFastHTTPClientCodec.Decode(msg, nil)
+	require.Error(t, err)
+
+	rsp.Reset()
+	rsp.SetBodyString("body")
+	_, msg = codec.WithNewMessage(context.Background())
+	handled := false
+	msg.WithClientRspHead(&thttp.FastHTTPClientRspHeader{
+		Response: rsp,
+		ResponseHandler: fastHTTPRspHandlerFunc(func(*fasthttp.Response) error {
+			handled = true
+			return nil
+		}),
+	})
+	body, err := thttp.DefaultFastHTTPClientCodec.Decode(msg, nil)
+	require.NoError(t, err)
+	require.Nil(t, body)
+	require.True(t, handled)
+
+	rsp.Reset()
+	rsp.SetBodyString("manual")
+	_, msg = codec.WithNewMessage(context.Background())
+	msg.WithClientRspHead(&thttp.FastHTTPClientRspHeader{Response: rsp, ManualReadBody: true})
+	body, err = thttp.DefaultFastHTTPClientCodec.Decode(msg, nil)
+	require.NoError(t, err)
+	require.Nil(t, body)
+}
+
+func TestFastHTTPServerDecodeDisabledAuto(t *testing.T) {
+	sc := thttp.FastHTTPServerCodec{
+		AutoReadBody:    false,
+		AutoGenTrpcHead: false,
+	}
+	requestCtx := &fasthttp.RequestCtx{}
+	ctx := thttp.WithRequestCtx(context.Background(), requestCtx)
+	msg := codec.Message(ctx)
+	body, err := sc.Decode(msg, nil)
+	require.NoError(t, err)
+	require.Nil(t, body)
+}
+
+type errSSEHandler struct{}
+
+func (errSSEHandler) Handle(*sse.Event) error {
+	return errors.New("sse error")
+}
+
+type fastHTTPRspHandlerFunc func(*fasthttp.Response) error
+
+func (f fastHTTPRspHandlerFunc) Handle(rsp *fasthttp.Response) error {
+	return f(rsp)
+}

--- a/http/fasthttp_service_desc.go
+++ b/http/fasthttp_service_desc.go
@@ -1,0 +1,64 @@
+//
+//
+// Tencent is pleased to support the open source community by making tRPC available.
+//
+// Copyright (C) 2023 Tencent.
+// All rights reserved.
+//
+// If you have downloaded a copy of the tRPC source code from Tencent,
+// please note that tRPC source code is licensed under the  Apache 2.0 License,
+// A copy of the Apache 2.0 License is included in this file.
+//
+//
+
+package http
+
+import (
+	"context"
+	"errors"
+
+	"github.com/valyala/fasthttp"
+	"trpc.group/trpc-go/trpc-go/server"
+)
+
+// CtxKey is used to store context.Context in requestCtx.
+type CtxKey struct{}
+
+// GetContext gets context.Context from requestCtx.
+func GetContext(requestCtx *fasthttp.RequestCtx) (context.Context, bool) {
+	ctx, ok := requestCtx.UserValue(CtxKey{}).(context.Context)
+	return ctx, ok
+}
+
+// FastHTTPHandleFunc registers fasthttp handler with custom route.
+// If handler need ctx (context.Context), users can get by requestCtx.UserValue(CtxKey{})
+func FastHTTPHandleFunc(pattern string, handler func(requestCtx *fasthttp.RequestCtx)) {
+	ServiceDesc.Methods = append(ServiceDesc.Methods, generateMethodFastHTTP(pattern, handler))
+}
+
+// generateMethod generates server method.
+func generateMethodFastHTTP(pattern string, handler fasthttp.RequestHandler) server.Method {
+	handlerFunc := func(_ interface{}, ctx context.Context, f server.FilterFunc) (rspBody interface{}, err error) {
+		filters, err := f(nil)
+		if err != nil {
+			return nil, err
+		}
+		handleFunc := func(ctx context.Context, _ interface{}) (rspBody interface{}, err error) {
+			requestCtx := RequestCtx(ctx)
+			if requestCtx == nil {
+				return nil, errors.New("fasthttp Handle missing requestCtx in context")
+			}
+			// Store context.Context.
+			requestCtx.SetUserValue(CtxKey{}, ctx)
+			// Handle error in handler.
+			// fasthttp.RequestHandler will NOT return err.
+			handler(requestCtx)
+			return nil, nil
+		}
+		return filters.Filter(ctx, nil, handleFunc)
+	}
+	return server.Method{
+		Name: pattern,
+		Func: handlerFunc,
+	}
+}

--- a/http/fasthttp_transport.go
+++ b/http/fasthttp_transport.go
@@ -1,0 +1,629 @@
+//
+//
+// Tencent is pleased to support the open source community by making tRPC available.
+//
+// Copyright (C) 2023 Tencent.
+// All rights reserved.
+//
+// If you have downloaded a copy of the tRPC source code from Tencent,
+// please note that tRPC source code is licensed under the  Apache 2.0 License,
+// A copy of the Apache 2.0 License is included in this file.
+//
+//
+
+package http
+
+import (
+	"bytes"
+	"context"
+	"crypto/tls"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"strconv"
+	"time"
+
+	"github.com/valyala/fasthttp"
+	"trpc.group/trpc-go/trpc-go/codec"
+	"trpc.group/trpc-go/trpc-go/errs"
+	icodec "trpc.group/trpc-go/trpc-go/internal/codec"
+	"trpc.group/trpc-go/trpc-go/internal/reuseport"
+	itls "trpc.group/trpc-go/trpc-go/internal/tls"
+	"trpc.group/trpc-go/trpc-go/log"
+	"trpc.group/trpc-go/trpc-go/rpcz"
+	"trpc.group/trpc-go/trpc-go/transport"
+	trpcpb "trpc.group/trpc/trpc-protocol/pb/go/trpc"
+)
+
+const defaultFastHTTPMaxRedirectsCount = 10
+
+func init() {
+	// Server transport (protocol file service).
+	transport.RegisterServerTransport(fastHTTPProtocol, DefaultFastHTTPServerTransport)
+
+	// Server transport (no protocol file service).
+	transport.RegisterServerTransport(fastHTTPNoProtocolProtocol, DefaultFastHTTPServerTransport)
+
+	// Client transport.
+	transport.RegisterClientTransport(fastHTTPProtocol, DefaultFastHTTPClientTransport)
+}
+
+// FastHTTPServerTransport is the fasthttp transport layer.
+// Users can directly configure the *fasthttp.Server by setting the Server field in FastHTTPServerTransport.
+// Alternatively, configuration can also be done through opts.
+// Note: The Server field is used as a template for creating new server instances
+// to avoid race conditions when multiple ListenAndServe calls happen concurrently.
+type FastHTTPServerTransport struct {
+	// Support external configuration as a template.
+	// This field is used as a template for creating new server instances
+	// to ensure thread safety when multiple ListenAndServe calls happen concurrently.
+	Server *fasthttp.Server
+	opts   *transport.ServerTransportOptions
+}
+
+var (
+	// DefaultFastHTTPClientTransport is the default fasthttp client transport.
+	DefaultFastHTTPClientTransport = NewFastHTTPClientTransport()
+	// DefaultFastHTTPServerTransport is the default fasthttp reuseport server transport.
+	DefaultFastHTTPServerTransport = NewFastHTTPServerTransport(transport.WithReusePort(true))
+)
+
+// NewFastHTTPServerTransport creates fasthttp transport. The default idle time
+// is set 1 min in config.go, which can be customized through ServerTransportOption.
+// After invoking NewFastHTTPServerTransport(), user can configure the *fasthttp.Server
+// by setting the Server field. Manually configuring st.Server.Handler by the user
+// may introduce risks, so user MUST configure the st.Server.Handler by ListenServeOption.
+func NewFastHTTPServerTransport(opt ...transport.ServerTransportOption) *FastHTTPServerTransport {
+	opts := &transport.ServerTransportOptions{}
+	for _, o := range opt {
+		o(opts)
+	}
+
+	return &FastHTTPServerTransport{
+		opts: opts,
+	}
+}
+
+// ListenAndServe handles configuration and provides fasthttp service.
+// The default network is tcp, which can be customized through ListenServeOption.
+// It implements the transport.ServerTransport interface for FastHTTPServerTransport.
+// Manually configuring st.Server.Handler by the user may introduce risks,
+// so user MUST configure the st.Server.Handler by ListenServeOption.
+func (st *FastHTTPServerTransport) ListenAndServe(
+	ctx context.Context, opt ...transport.ListenServeOption) error {
+	opts := &transport.ListenServeOptions{
+		Network: "tcp",
+	}
+	for _, o := range opt {
+		o(opts)
+	}
+	// Manually configuring st.Server.Handler by the user may introduce risks,
+	// so user MUST configure the st.Server.Handler by ListenServeOption.
+	if opts.Handler == nil {
+		return errors.New("fasthttp server transport handler empty")
+	}
+	return st.listenAndServeFastHTTP(ctx, opts)
+}
+
+// listenAndServeFastHTTP handles configuration and provides fasthttp service.
+func (st *FastHTTPServerTransport) listenAndServeFastHTTP(
+	ctx context.Context, opts *transport.ListenServeOptions) error {
+	server, err := st.configureFastHTTPServer(ctx, opts)
+	if err != nil {
+		return err
+	}
+	return st.serve(ctx, server, opts)
+}
+
+// configureFastHTTPServer configures a new fasthttp server instance
+// based on the provided options or default values.
+// It creates a new server instance to avoid race conditions
+// when multiple ListenAndServe calls happen concurrently.
+func (st *FastHTTPServerTransport) configureFastHTTPServer(
+	ctx context.Context,
+	opts *transport.ListenServeOptions,
+) (*fasthttp.Server, error) {
+	// Create a new server instance to avoid race conditions.
+	server := &fasthttp.Server{}
+
+	// If a template server is provided, copy its configuration.
+	if st.Server != nil {
+		copyServerConfig(server, st.Server)
+	}
+
+	// Wrap opts.Handler for server.Handler.
+	server.Handler = func(requestCtx *fasthttp.RequestCtx) {
+		// User should avoid holding references to incoming RequestCtx and/or
+		// its members after the Handler return.
+		ctx := WithRequestCtx(ctx, requestCtx)
+		// Generates new empty general message structure data and save it to ctx.
+		ctx, msg := codec.WithNewMessage(ctx)
+		defer codec.PutBackMessage(msg)
+		// Store context.Context.
+		requestCtx.SetUserValue(CtxKey{}, ctx)
+
+		span, ender, ctx := rpcz.NewSpanContext(ctx, "fasthttp-server")
+		defer ender.End()
+		span.SetAttribute(rpcz.HTTPAttributeURL, requestCtx.URI().String())
+		span.SetAttribute(rpcz.HTTPAttributeRequestContentLength, requestCtx.Request.Header.ContentLength())
+
+		msg.WithLocalAddr(requestCtx.LocalAddr())
+		msg.WithRemoteAddr(requestCtx.RemoteAddr())
+
+		_, err := opts.Handler.Handle(ctx, nil)
+		if err != nil {
+			span.SetAttribute(rpcz.TRPCAttributeError, err)
+			log.Errorf("fasthttp server transport handle fail: %w", err)
+			if errors.Is(err, ErrEncodeMissingRequestCtx) || errors.Is(err, errs.ErrServerNoResponse) {
+				requestCtx.SetStatusCode(fasthttp.StatusInternalServerError)
+				fmt.Fprintf(requestCtx, "fasthttp server handle error: %+v", err)
+			}
+			return
+		}
+	}
+
+	if opts.DisableKeepAlives {
+		server.DisableKeepalive = true
+	}
+
+	// Configure the server.TLSConfig for https.
+	// Enable fasthttp server to verify client certificate.
+	if len(opts.CACertFile) != 0 {
+		server.TLSConfig = &tls.Config{
+			MinVersion: tls.VersionTLS12,
+			ClientAuth: tls.RequireAndVerifyClientCert,
+		}
+		certPool, err := itls.GetCertPool(opts.CACertFile, opts.TLSCertProvider)
+		if err != nil {
+			return nil, fmt.Errorf("fasthttp server get ca cert file error: %w", err)
+		}
+		server.TLSConfig.ClientCAs = certPool
+	}
+
+	// The priority of options is strange but align with thttp.
+	// Now ServerTransportOptions prioritized over the priority of ListenServeOptions,
+	// Although Server these two should be at the same level (because LAS will only be performed once),
+	// but if we compare it to Client, it would be equivalent to
+	// ClientTransportOptions prioritized over RoundTripOptions.
+	idleTimeout := opts.IdleTimeout
+	if st.opts.IdleTimeout > 0 {
+		idleTimeout = st.opts.IdleTimeout
+	}
+	server.IdleTimeout = idleTimeout
+	return server, nil
+}
+
+// copyServerConfig copies configuration fields from template to target server.
+// This avoids copying the noCopy field which would cause compilation errors.
+func copyServerConfig(target, template *fasthttp.Server) {
+	target.Name = template.Name
+	target.HeaderReceived = template.HeaderReceived
+	target.ContinueHandler = template.ContinueHandler
+	target.IdleTimeout = template.IdleTimeout
+	target.ReadTimeout = template.ReadTimeout
+	target.WriteTimeout = template.WriteTimeout
+	target.MaxKeepaliveDuration = template.MaxKeepaliveDuration
+	target.MaxConnsPerIP = template.MaxConnsPerIP
+	target.MaxRequestsPerConn = template.MaxRequestsPerConn
+	target.MaxIdleWorkerDuration = template.MaxIdleWorkerDuration
+	target.TCPKeepalive = template.TCPKeepalive
+	target.TCPKeepalivePeriod = template.TCPKeepalivePeriod
+	target.MaxRequestBodySize = template.MaxRequestBodySize
+	target.DisableKeepalive = template.DisableKeepalive
+	target.KeepHijackedConns = template.KeepHijackedConns
+	target.CloseOnShutdown = template.CloseOnShutdown
+	target.GetOnly = template.GetOnly
+	target.ReduceMemoryUsage = template.ReduceMemoryUsage
+	target.StreamRequestBody = template.StreamRequestBody
+	target.DisablePreParseMultipartForm = template.DisablePreParseMultipartForm
+	target.LogAllErrors = template.LogAllErrors
+	target.SecureErrorLogMessage = template.SecureErrorLogMessage
+	target.DisableHeaderNamesNormalizing = template.DisableHeaderNamesNormalizing
+	target.SleepWhenConcurrencyLimitsExceeded = template.SleepWhenConcurrencyLimitsExceeded
+	target.NoDefaultServerHeader = template.NoDefaultServerHeader
+	target.NoDefaultContentType = template.NoDefaultContentType
+	target.NoDefaultDate = template.NoDefaultDate
+	if template.TLSConfig != nil {
+		target.TLSConfig = template.TLSConfig.Clone()
+	}
+	target.Logger = template.Logger
+}
+
+// serve uses the fasthttp server to provide services.
+func (st *FastHTTPServerTransport) serve(ctx context.Context, server *fasthttp.Server, opts *transport.ListenServeOptions) error {
+	ln, err := getFastHTTPListener(opts, st.opts.ReusePort)
+	if err != nil {
+		return fmt.Errorf("fasthttp server transport get listener err: %w", err)
+	}
+	if err := transport.SaveListener(ln); err != nil {
+		return fmt.Errorf("save listener error: %w", err)
+	}
+
+	// ServeTLS will only be invoked if TLSKeyFile and TLSCertFile are configured.
+	if len(opts.TLSKeyFile) != 0 && len(opts.TLSCertFile) != 0 {
+		// We have already initialized the TLSConfig and created a cert pool for ClientCAs.
+		// Therefore, we only need to load the TLS key pairs here.
+		certs, err := itls.LoadTLSKeyPairs(opts.TLSCertFile, opts.TLSKeyFile, opts.TLSCertProvider)
+		if err != nil {
+			return fmt.Errorf("load tls key pairs err: %w", err)
+		}
+		// If opts.CACertFile is empty, TLSConfig will be nil. Check it first.
+		if server.TLSConfig == nil {
+			server.TLSConfig = &tls.Config{MinVersion: tls.VersionTLS12}
+		}
+		server.TLSConfig.Certificates = certs
+
+		go func() {
+			// The TLSConfig has been initialized, including ClientCAs and Certificates.
+			// Therefore, it is only necessary to pass empty cert and key files to ServeTLS.
+			if err := server.ServeTLS(tcpKeepAliveListener{TCPListener: ln.(*net.TCPListener)},
+				"", ""); err != nil {
+				log.Errorf("serve TLS failed: %v", err)
+			}
+		}()
+	} else {
+		go func() {
+			if err := server.Serve(tcpKeepAliveListener{TCPListener: ln.(*net.TCPListener)}); err != nil {
+				log.Errorf("serve err: %w", err)
+			}
+		}()
+	}
+
+	go func() {
+		<-ctx.Done()
+		if err := server.Shutdown(); err != nil {
+			log.Infof("shutdown err: %w", err)
+		}
+	}()
+	go func() {
+		<-opts.StopListening
+		_ = ln.Close()
+	}()
+
+	return nil
+}
+
+func getFastHTTPListener(opts *transport.ListenServeOptions, reusePort bool) (net.Listener, error) {
+	if opts.Listener != nil {
+		return opts.Listener, nil
+	}
+
+	v, _ := os.LookupEnv(transport.EnvGraceRestart)
+	ok, _ := strconv.ParseBool(v)
+	if ok {
+		pln, err := transport.GetPassedListener(opts.Network, opts.Address)
+		if err != nil {
+			return nil, err
+		}
+		ln, ok := pln.(net.Listener)
+		if !ok {
+			return nil, fmt.Errorf("invalid listener type, want net.Listener, got %T", pln)
+		}
+		return ln, nil
+	}
+
+	if reusePort {
+		ln, err := reuseport.Listen(opts.Network, opts.Address)
+		if err != nil {
+			return nil, fmt.Errorf("fasthttp reuseport listen error: %w", err)
+		}
+		return ln, nil
+	}
+
+	ln, err := net.Listen(opts.Network, opts.Address)
+	if err != nil {
+		return nil, fmt.Errorf("fasthttp listen error: %w", err)
+	}
+	return ln, nil
+}
+
+// FastHTTPClientTransport client side http transport.
+// Users can directly configure the *fasthttp.Client by setting the Client field in FastHTTPClientTransport.
+// Alternatively, configuration can also be done through opts.
+type FastHTTPClientTransport struct {
+	// Fasthttp client, exposed variables, allows user to customize settings.
+	Client *fasthttp.Client
+	opts   *transport.ClientTransportOptions
+}
+
+// NewFastHTTPClientTransport creates fasthttp transport.
+func NewFastHTTPClientTransport(ctOpt ...transport.ClientTransportOption) *FastHTTPClientTransport {
+	ctOpts := &transport.ClientTransportOptions{}
+	for _, o := range ctOpt {
+		o(ctOpts)
+	}
+	if ctOpts.MaxRedirectsCount == 0 {
+		ctOpts.MaxRedirectsCount = defaultFastHTTPMaxRedirectsCount
+	}
+
+	return &FastHTTPClientTransport{
+		Client: &fasthttp.Client{},
+		opts:   ctOpts,
+	}
+}
+
+// RoundTrip implements the transport.ClientTransport interface for FastHTTPClientTransport.
+// RoundTrip sends and receives fasthttp packets, put fasthttp response into ctx,
+// and no need to return rspBuf here.
+// TODO: trace
+func (ct *FastHTTPClientTransport) RoundTrip(
+	ctx context.Context,
+	reqBody []byte,
+	opt ...transport.RoundTripOption,
+) ([]byte, error) {
+	msg := codec.Message(ctx)
+	reqHeader, ok := msg.ClientReqHead().(*FastHTTPClientReqHeader)
+	if !ok {
+		errMsg := fmt.Sprintf(
+			"fasthttp client transport: ClientReqHead should be type of *FastHTTPClientReqHeader, current type: %T",
+			reqHeader,
+		)
+		return nil, errs.NewFrameError(errs.RetClientEncodeFail, errMsg)
+	}
+	rspHeader, ok := msg.ClientRspHead().(*FastHTTPClientRspHeader)
+	if !ok {
+		errMsg := fmt.Sprintf(
+			"fasthttp client transport: ClientReqHead should be type of *FastHTTPClientRspHeader, current type: %T",
+			rspHeader,
+		)
+		return nil, errs.NewFrameError(errs.RetClientEncodeFail, errMsg)
+	}
+
+	opts := &transport.RoundTripOptions{}
+	for _, o := range opt {
+		o(opts)
+	}
+
+	requestWasNil := reqHeader.Request == nil
+	if err := ct.getRequest(reqHeader, reqBody, msg, opts); err != nil {
+		return nil, err
+	}
+	if requestWasNil {
+		acquiredRequest := reqHeader.Request
+		defer fasthttp.ReleaseRequest(acquiredRequest)
+	}
+	if rspHeader.SSEHandler != nil {
+		if len(reqHeader.Request.Header.Peek(fasthttp.HeaderAccept)) == 0 {
+			reqHeader.Request.Header.Add(fasthttp.HeaderAccept, "text/event-stream")
+		}
+		if len(reqHeader.Request.Header.Peek(fasthttp.HeaderConnection)) == 0 {
+			reqHeader.Request.Header.Add(fasthttp.HeaderConnection, "keep-alive")
+		}
+		if len(reqHeader.Request.Header.Peek(fasthttp.HeaderCacheControl)) == 0 {
+			reqHeader.Request.Header.Add(fasthttp.HeaderCacheControl, "no-cache")
+		}
+	}
+
+	if rspHeader.Response == nil {
+		rspHeader.Response = fasthttp.AcquireResponse()
+	}
+
+	// tfasthttp does NOT have explicitHTTPS, it won't change opts.CACertFile == "" to InsecureSkipVerify.
+	// opts.CACertFile == "" means http,
+	// opts.CACertFile == "none" means https + InsecureSkipVerify,
+	// opts.CACertFile == "xxx" means https + Verify.
+	if len(opts.CACertFile) != 0 {
+		conf, err := itls.GetClientConfig(
+			opts.TLSServerName, opts.CACertFile, opts.TLSCertFile, opts.TLSKeyFile, opts.TLSCertProvider,
+		)
+		if err != nil {
+			return nil, errs.WrapFrameError(err, errs.RetClientConnectFail, "fail to get client config for tls")
+		}
+		ct.Client.TLSConfig = conf
+	}
+
+	// Use DecorateRequest to make the final modifications to the request before sending it out.
+	if reqHeader.DecorateRequest != nil {
+		reqHeader.Request = reqHeader.DecorateRequest(reqHeader.Request)
+		if reqHeader.Request == nil {
+			return nil, errs.NewFrameError(errs.RetClientEncodeFail,
+				"fasthttp client transport: DecorateRequest returned nil")
+		}
+	}
+
+	// Handle timeout and redirect.
+	if t, ok := ctx.Deadline(); ok {
+		reqHeader.Request.SetTimeout(time.Until(t))
+	}
+
+	if err := ct.Client.DoRedirects(reqHeader.Request, rspHeader.Response, ct.opts.MaxRedirectsCount); err != nil {
+		if err == fasthttp.ErrTimeout {
+			return nil, errs.NewFrameError(errs.RetClientTimeout,
+				"fasthttp client transport RoundTrip timeout: "+err.Error())
+		}
+		if ctx.Err() == context.Canceled {
+			return nil, errs.NewFrameError(errs.RetClientCanceled,
+				"fasthttp client transport RoundTrip canceled: "+err.Error())
+		}
+		return nil, errs.NewFrameError(errs.RetClientNetErr,
+			"fasthttp client transport RoundTrip: "+err.Error())
+	}
+	return nil, nil
+}
+
+// 1. Obtain a fasthttp.Request for reqHeader, usually for FastHTTPClientProxy invocation.
+// 2. Set the relevant fields from msg into the request headers.
+func (ct *FastHTTPClientTransport) getRequest(
+	reqHeader *FastHTTPClientReqHeader,
+	reqBody []byte,
+	msg codec.Msg,
+	opts *transport.RoundTripOptions,
+) error {
+	if request := reqHeader.Request; request == nil {
+		req, err := ct.acquireRequest(reqHeader, reqBody, msg, opts)
+		if err != nil {
+			return err
+		}
+		reqHeader.Request = req
+	} else if len(request.Host()) == 0 && bytes.Equal(request.RequestURI(), []byte("/")) {
+		// If RequestURI is empty or "/", rebuild the complete URI with scheme, address and RPC name
+		scheme := inferScheme(reqHeader.Scheme, opts.CACertFile)
+		request.SetRequestURI(buildRequestURI(scheme, opts.Address, msg.ClientRPCName()))
+	}
+	req := reqHeader.Request
+	req.Header.Set(canonicalTrpcCaller, msg.CallerServiceName())
+	req.Header.Set(canonicalTrpcCallee, msg.CalleeServiceName())
+	req.Header.Set(canonicalTrpcTimeout, strconv.FormatInt(msg.RequestTimeout().Milliseconds(), 10))
+
+	if opts.DisableConnectionPool {
+		req.SetConnectionClose()
+	}
+
+	if t := msg.CompressType(); icodec.IsValidCompressType(t) && t != codec.CompressTypeNoop {
+		req.Header.Set(canonicalContentEncoding, compressTypeContentEncoding[t])
+	}
+
+	if v := msg.SerializationType(); v != codec.SerializationTypeNoop &&
+		len(req.Header.Peek(canonicalContentType)) == 0 {
+		req.Header.Set(canonicalContentType, serializationTypeContentType[v])
+	}
+
+	if err := ct.setTransInfo(msg, req); err != nil {
+		return err
+	}
+
+	if len(opts.TLSServerName) == 0 {
+		opts.TLSServerName = string(req.URI().Host())
+	}
+
+	return nil
+}
+
+// acquireRequest is often used by FastHTTPClientProxy, and it sets
+// the relevant request Method, URI, reqBody, and Host.
+// Request is acquired and released in fasthttp.
+func (ct *FastHTTPClientTransport) acquireRequest(
+	reqHeader *FastHTTPClientReqHeader,
+	reqBody []byte,
+	msg codec.Msg,
+	rtOpts *transport.RoundTripOptions,
+) (*fasthttp.Request, error) {
+	req := fasthttp.AcquireRequest()
+	req.Header.SetMethod(reqHeader.Method)
+
+	// Set the request URI
+	scheme := inferScheme(reqHeader.Scheme, rtOpts.CACertFile)
+	req.SetRequestURI(buildRequestURI(scheme, rtOpts.Address, msg.ClientRPCName()))
+
+	req.SetBody(reqBody)
+	// After SetRequestURI.
+	if len(reqHeader.Host) != 0 {
+		req.SetHost(reqHeader.Host)
+	}
+
+	// Align With req, err := net/http.NewRequest(method, url, body).
+	if err := checkRequest(req); err != nil {
+		// Remember to releaseRequest.
+		fasthttp.ReleaseRequest(req)
+		return nil, errs.NewFrameError(errs.RetClientNetErr,
+			"fasthttp client transport acquireRequest: "+err.Error())
+	}
+	return req, nil
+}
+
+// checkRequest checks fasthttp request with the logic of net/http.NewRequest.
+func checkRequest(req *fasthttp.Request) error {
+	if len(req.Header.Method()) == 0 {
+		return errors.New("method cannot be empty")
+	}
+
+	uri := req.URI()
+	if req.URI() == nil {
+		return errors.New("URI cannot be nil")
+	}
+
+	scheme := string(uri.Scheme())
+	if scheme == "" {
+		return errors.New("URL scheme cannot be empty")
+	}
+
+	if scheme != "http" && scheme != "https" {
+		return fmt.Errorf("unsupported URL scheme %s", scheme)
+	}
+
+	if len(uri.Host()) == 0 {
+		return errors.New("URL host cannot be empty")
+	}
+	return nil
+}
+
+// setTransInfo add the TransInfo in the msg to fasthttp.Request.Header.
+func (ct *FastHTTPClientTransport) setTransInfo(msg codec.Msg, req *fasthttp.Request) error {
+	// Delay the allocation of a map to avoid unnecessary memory allocation.
+	// When adding new branches to the subsequent code, please remember to
+	// check if the map is nil and construct it promptly.
+	var m map[string]string
+
+	if md := msg.ClientMetaData(); len(md) > 0 {
+		m = make(map[string]string, len(md))
+		for k, v := range md {
+			m[k] = encodeBytes(v, ct.opts.DisableHTTPEncodeTransInfoBase64)
+		}
+	}
+
+	if msg.Dyeing() {
+		if m == nil {
+			m = make(map[string]string)
+		}
+		m[TrpcDyeingKey] = encodeString(msg.DyeingKey(), ct.opts.DisableHTTPEncodeTransInfoBase64)
+		req.Header.Set(canonicalTrpcMessageType,
+			strconv.Itoa(int(trpcpb.TrpcMessageType_TRPC_DYEING_MESSAGE)))
+	}
+
+	if msg.EnvTransfer() != "" {
+		if m == nil {
+			m = make(map[string]string)
+		}
+		m[TrpcEnv] = encodeString(msg.EnvTransfer(), ct.opts.DisableHTTPEncodeTransInfoBase64)
+	} else {
+		// If msg.EnvTransfer() empty, transmitted env info in req.TransInfo should be cleared.
+		// The map needs to be constructed only when assigning values to it.
+		// It is valid to check existence of an element in a nil map.
+		if _, ok := m[TrpcEnv]; ok {
+			m[TrpcEnv] = ""
+		}
+	}
+
+	if len(m) > 0 {
+		val, err := codec.Marshal(codec.SerializationTypeJSON, m)
+		if err != nil {
+			return errs.NewFrameError(
+				errs.RetClientValidateFail, "fasthttp client json marshal metadata fail: "+err.Error(),
+			)
+		}
+		req.Header.Set(canonicalTrpcTransInfo, string(val))
+	}
+
+	return nil
+}
+
+func buildRequestURI(scheme, addr, path string) string {
+	return fmt.Sprintf("%s://%s%s", scheme, addr, path)
+}
+
+// inferScheme just by scheme and TLS config in tfasthttp without explicitHTTPS.
+func inferScheme(scheme string, caCertFile string) string {
+	if scheme != "" {
+		return scheme
+	}
+	if len(caCertFile) > 0 {
+		return "https"
+	}
+	return "http"
+}
+
+func encodeBytes(in []byte, disableHTTPEncodeTransInfoBase64 bool) string {
+	if disableHTTPEncodeTransInfoBase64 {
+		return string(in)
+	}
+	return base64.StdEncoding.EncodeToString(in)
+}
+
+func encodeString(in string, disableHTTPEncodeTransInfoBase64 bool) string {
+	if disableHTTPEncodeTransInfoBase64 {
+		return in
+	}
+	return base64.StdEncoding.EncodeToString([]byte(in))
+}

--- a/http/fasthttp_transport_internal_test.go
+++ b/http/fasthttp_transport_internal_test.go
@@ -1,0 +1,221 @@
+//
+//
+// Tencent is pleased to support the open source community by making tRPC available.
+//
+// Copyright (C) 2023 Tencent.
+// All rights reserved.
+//
+// If you have downloaded a copy of the tRPC source code from Tencent,
+// please note that tRPC source code is licensed under the  Apache 2.0 License,
+// A copy of the Apache 2.0 License is included in this file.
+//
+//
+
+package http
+
+import (
+	"context"
+	"crypto/tls"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"net"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/valyala/fasthttp"
+	trpcpb "trpc.group/trpc/trpc-protocol/pb/go/trpc"
+
+	"trpc.group/trpc-go/trpc-go/codec"
+	"trpc.group/trpc-go/trpc-go/filter"
+	"trpc.group/trpc-go/trpc-go/transport"
+)
+
+func TestFastHTTPServiceDesc(t *testing.T) {
+	defer func() { ServiceDesc.Methods = ServiceDesc.Methods[:0] }()
+
+	requestCtx := &fasthttp.RequestCtx{}
+	baseCtx := context.Background()
+	requestCtx.SetUserValue(CtxKey{}, baseCtx)
+	gotCtx, ok := GetContext(requestCtx)
+	require.True(t, ok)
+	require.Equal(t, baseCtx, gotCtx)
+
+	requestCtx.SetUserValue(CtxKey{}, "invalid")
+	gotCtx, ok = GetContext(requestCtx)
+	require.False(t, ok)
+	require.Nil(t, gotCtx)
+
+	called := false
+	FastHTTPHandleFunc("/fast", func(ctx *fasthttp.RequestCtx) {
+		called = true
+		ctx.SetStatusCode(fasthttp.StatusNoContent)
+	})
+	require.Len(t, ServiceDesc.Methods, 1)
+
+	ctx := WithRequestCtx(context.Background(), requestCtx)
+	_, err := ServiceDesc.Methods[0].Func(nil, ctx, func(interface{}) (filter.ServerChain, error) {
+		return filter.ServerChain{}, nil
+	})
+	require.NoError(t, err)
+	require.True(t, called)
+	require.Equal(t, fasthttp.StatusNoContent, requestCtx.Response.StatusCode())
+
+	_, err = ServiceDesc.Methods[0].Func(nil, context.Background(), func(interface{}) (filter.ServerChain, error) {
+		return filter.ServerChain{}, nil
+	})
+	require.ErrorContains(t, err, "missing requestCtx")
+
+	_, err = ServiceDesc.Methods[0].Func(nil, ctx, func(interface{}) (filter.ServerChain, error) {
+		return nil, errors.New("filter error")
+	})
+	require.ErrorContains(t, err, "filter error")
+}
+
+func TestFastHTTPTransportPrivateHelpers(t *testing.T) {
+	require.Equal(t, "https://example.com/path", buildRequestURI("https", "example.com", "/path"))
+	require.Equal(t, "custom", inferScheme("custom", ""))
+	require.Equal(t, "https", inferScheme("", "ca.pem"))
+	require.Equal(t, "http", inferScheme("", ""))
+	require.Equal(t, "value", encodeBytes([]byte("value"), true))
+	require.Equal(t, base64.StdEncoding.EncodeToString([]byte("value")), encodeBytes([]byte("value"), false))
+	require.Equal(t, "value", encodeString("value", true))
+	require.Equal(t, base64.StdEncoding.EncodeToString([]byte("value")), encodeString("value", false))
+}
+
+func TestFastHTTPCheckRequest(t *testing.T) {
+	req := fasthttp.AcquireRequest()
+	defer fasthttp.ReleaseRequest(req)
+
+	req.Header.SetMethod(fasthttp.MethodGet)
+	require.ErrorContains(t, checkRequest(req), "URL host cannot be empty")
+
+	req.SetRequestURI("ftp://example.com/path")
+	require.ErrorContains(t, checkRequest(req), "unsupported URL scheme")
+
+	req.SetRequestURI("http:///path")
+	require.ErrorContains(t, checkRequest(req), "URL host cannot be empty")
+
+	req.SetRequestURI("http://example.com/path")
+	require.NoError(t, checkRequest(req))
+}
+
+func TestFastHTTPGetRequestSetsHeaders(t *testing.T) {
+	ct := NewFastHTTPClientTransport()
+	ctx, msg := codec.WithNewMessage(context.Background())
+	defer codec.PutBackMessage(msg)
+	msg.WithClientRPCName("/hello")
+	msg.WithCallerServiceName("trpc.test.client")
+	msg.WithCalleeServiceName("trpc.test.server")
+	msg.WithRequestTimeout(2 * time.Second)
+	msg.WithSerializationType(codec.SerializationTypeJSON)
+	msg.WithClientMetaData(codec.MetaData{"meta-key": []byte("meta-value")})
+	msg.WithDyeing(true)
+	msg.WithDyeingKey("dye-key")
+	msg.WithEnvTransfer("production")
+	_ = ctx
+
+	reqHeader := &FastHTTPClientReqHeader{Method: fasthttp.MethodPost}
+	opts := &transport.RoundTripOptions{Address: "example.com:80"}
+	require.NoError(t, ct.getRequest(reqHeader, []byte(`{"name":"trpc"}`), msg, opts))
+	defer fasthttp.ReleaseRequest(reqHeader.Request)
+
+	req := reqHeader.Request
+	require.Equal(t, fasthttp.MethodPost, string(req.Header.Method()))
+	require.Equal(t, "http://example.com:80/hello", req.URI().String())
+	require.Equal(t, "example.com:80", opts.TLSServerName)
+	require.Equal(t, "trpc.test.client", string(req.Header.Peek(TrpcCaller)))
+	require.Equal(t, "trpc.test.server", string(req.Header.Peek(TrpcCallee)))
+	require.Equal(t, "2000", string(req.Header.Peek(TrpcTimeout)))
+	require.Equal(t, serializationTypeContentType[codec.SerializationTypeJSON], string(req.Header.Peek(fasthttp.HeaderContentType)))
+	require.Equal(t, []byte(`{"name":"trpc"}`), req.Body())
+	require.Equal(t,
+		strconv.Itoa(int(trpcpb.TrpcMessageType_TRPC_DYEING_MESSAGE)),
+		string(req.Header.Peek(canonicalTrpcMessageType)),
+	)
+
+	var transInfo map[string]string
+	require.NoError(t, json.Unmarshal(req.Header.Peek(TrpcTransInfo), &transInfo))
+	require.Equal(t, base64.StdEncoding.EncodeToString([]byte("meta-value")), transInfo["meta-key"])
+	require.Equal(t, base64.StdEncoding.EncodeToString([]byte("dye-key")), transInfo[TrpcDyeingKey])
+	require.Equal(t, base64.StdEncoding.EncodeToString([]byte("production")), transInfo[TrpcEnv])
+}
+
+func TestFastHTTPGetRequestWithProvidedRequest(t *testing.T) {
+	ct := NewFastHTTPClientTransport(transport.WithDisableEncodeTransInfoBase64())
+	ctx, msg := codec.WithNewMessage(context.Background())
+	defer codec.PutBackMessage(msg)
+	msg.WithClientRPCName("/provided")
+	msg.WithCallerServiceName("trpc.test.client")
+	msg.WithCalleeServiceName("trpc.test.server")
+	msg.WithSerializationType(codec.SerializationTypeJSON)
+	msg.WithClientMetaData(codec.MetaData{"meta-key": []byte("meta-value")})
+	_ = ctx
+
+	req := fasthttp.AcquireRequest()
+	defer fasthttp.ReleaseRequest(req)
+	req.Header.SetMethod(fasthttp.MethodGet)
+	reqHeader := &FastHTTPClientReqHeader{Request: req}
+	opts := &transport.RoundTripOptions{Address: "example.com:80", DisableConnectionPool: true}
+	require.NoError(t, ct.getRequest(reqHeader, nil, msg, opts))
+	require.Equal(t, "http://example.com:80/provided", req.URI().String())
+	require.True(t, req.ConnectionClose())
+
+	var transInfo map[string]string
+	require.NoError(t, json.Unmarshal(req.Header.Peek(TrpcTransInfo), &transInfo))
+	require.Equal(t, "meta-value", transInfo["meta-key"])
+}
+
+func TestFastHTTPCopyServerConfig(t *testing.T) {
+	template := &fasthttp.Server{
+		Name:                  "template",
+		IdleTimeout:           time.Second,
+		ReadTimeout:           2 * time.Second,
+		WriteTimeout:          3 * time.Second,
+		MaxConnsPerIP:         4,
+		DisableKeepalive:      true,
+		NoDefaultServerHeader: true,
+		TLSConfig:             &tls.Config{ServerName: "example.com", MinVersion: tls.VersionTLS12},
+	}
+	target := &fasthttp.Server{}
+	copyServerConfig(target, template)
+
+	require.Equal(t, template.Name, target.Name)
+	require.Equal(t, template.IdleTimeout, target.IdleTimeout)
+	require.Equal(t, template.ReadTimeout, target.ReadTimeout)
+	require.Equal(t, template.WriteTimeout, target.WriteTimeout)
+	require.Equal(t, template.MaxConnsPerIP, target.MaxConnsPerIP)
+	require.Equal(t, template.DisableKeepalive, target.DisableKeepalive)
+	require.Equal(t, template.NoDefaultServerHeader, target.NoDefaultServerHeader)
+	require.Equal(t, "example.com", target.TLSConfig.ServerName)
+	require.NotSame(t, template.TLSConfig, target.TLSConfig)
+}
+
+func TestFastHTTPConfigureServerAndListener(t *testing.T) {
+	st := NewFastHTTPServerTransport(transport.WithReusePort(false), transport.WithIdleTimeout(2*time.Second))
+	st.Server = &fasthttp.Server{Name: "template"}
+	server, err := st.configureFastHTTPServer(context.Background(), &transport.ListenServeOptions{
+		DisableKeepAlives: true,
+		IdleTimeout:       time.Second,
+	})
+	require.NoError(t, err)
+	require.Equal(t, "template", server.Name)
+	require.True(t, server.DisableKeepalive)
+	require.Equal(t, 2*time.Second, server.IdleTimeout)
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer ln.Close()
+	got, err := getFastHTTPListener(&transport.ListenServeOptions{Listener: ln}, true)
+	require.NoError(t, err)
+	require.Equal(t, ln, got)
+
+	got, err = getFastHTTPListener(&transport.ListenServeOptions{
+		Network: "tcp",
+		Address: "127.0.0.1:0",
+	}, false)
+	require.NoError(t, err)
+	require.NoError(t, got.Close())
+}

--- a/http/fasthttp_transport_test.go
+++ b/http/fasthttp_transport_test.go
@@ -1,0 +1,130 @@
+//
+//
+// Tencent is pleased to support the open source community by making tRPC available.
+//
+// Copyright (C) 2023 Tencent.
+// All rights reserved.
+//
+// If you have downloaded a copy of the tRPC source code from Tencent,
+// please note that tRPC source code is licensed under the  Apache 2.0 License,
+// A copy of the Apache 2.0 License is included in this file.
+//
+//
+
+package http_test
+
+import (
+	"context"
+	"errors"
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/valyala/fasthttp"
+
+	"trpc.group/trpc-go/trpc-go/codec"
+	thttp "trpc.group/trpc-go/trpc-go/http"
+	"trpc.group/trpc-go/trpc-go/transport"
+)
+
+func TestFastHTTPRegistration(t *testing.T) {
+	require.NotNil(t, codec.GetServer("fasthttp"))
+	require.NotNil(t, codec.GetClient("fasthttp"))
+	require.NotNil(t, codec.GetServer("fasthttp_no_protocol"))
+	require.NotNil(t, transport.GetServerTransport("fasthttp"))
+	require.NotNil(t, transport.GetServerTransport("fasthttp_no_protocol"))
+	require.NotNil(t, transport.GetClientTransport("fasthttp"))
+}
+
+func TestFastHTTPServerTransportServe(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	st := thttp.NewFastHTTPServerTransport(transport.WithReusePort(false))
+	err = st.ListenAndServe(ctx,
+		transport.WithListener(ln),
+		transport.WithHandler(transportHandlerFunc(func(ctx context.Context, _ []byte) ([]byte, error) {
+			requestCtx := thttp.RequestCtx(ctx)
+			if requestCtx == nil {
+				return nil, errors.New("missing fasthttp request context")
+			}
+			requestCtx.SetStatusCode(fasthttp.StatusAccepted)
+			requestCtx.SetBodyString("ok")
+			return nil, nil
+		})),
+	)
+	require.NoError(t, err)
+
+	status, body, err := fasthttp.Get(nil, "http://"+ln.Addr().String()+"/ping")
+	require.NoError(t, err)
+	require.Equal(t, fasthttp.StatusAccepted, status)
+	require.Equal(t, "ok", string(body))
+}
+
+func TestFastHTTPClientTransportRoundTrip(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer ln.Close()
+
+	server := &fasthttp.Server{
+		Handler: func(ctx *fasthttp.RequestCtx) {
+			if string(ctx.Method()) != fasthttp.MethodGet || string(ctx.Path()) != "/hello" {
+				ctx.SetStatusCode(fasthttp.StatusBadRequest)
+				return
+			}
+			ctx.SetStatusCode(fasthttp.StatusCreated)
+			ctx.Response.Header.SetContentType("application/json")
+			ctx.SetBodyString(`{"msg":"ok"}`)
+		},
+	}
+	go func() {
+		_ = server.Serve(ln)
+	}()
+	defer server.Shutdown()
+
+	ctx, msg := codec.WithNewMessage(context.Background())
+	defer codec.PutBackMessage(msg)
+	msg.WithClientRPCName("/hello")
+	msg.WithCallerServiceName("trpc.test.client")
+	msg.WithCalleeServiceName("trpc.test.server")
+	msg.WithSerializationType(codec.SerializationTypeJSON)
+
+	rsp := fasthttp.AcquireResponse()
+	defer fasthttp.ReleaseResponse(rsp)
+	msg.WithClientReqHead(&thttp.FastHTTPClientReqHeader{Method: fasthttp.MethodGet})
+	msg.WithClientRspHead(&thttp.FastHTTPClientRspHeader{Response: rsp})
+
+	ct := thttp.NewFastHTTPClientTransport()
+	_, err = ct.RoundTrip(ctx, nil, transport.WithDialAddress(ln.Addr().String()))
+	require.NoError(t, err)
+	require.Equal(t, fasthttp.StatusCreated, rsp.StatusCode())
+	require.Equal(t, `{"msg":"ok"}`, string(rsp.Body()))
+}
+
+func TestFastHTTPClientTransportRejectsNilDecoratedRequest(t *testing.T) {
+	ctx, msg := codec.WithNewMessage(context.Background())
+	defer codec.PutBackMessage(msg)
+	msg.WithClientRPCName("/hello")
+	msg.WithCallerServiceName("trpc.test.client")
+	msg.WithCalleeServiceName("trpc.test.server")
+	msg.WithClientReqHead(&thttp.FastHTTPClientReqHeader{
+		Method: fasthttp.MethodGet,
+		DecorateRequest: func(*fasthttp.Request) *fasthttp.Request {
+			return nil
+		},
+	})
+	msg.WithClientRspHead(&thttp.FastHTTPClientRspHeader{})
+
+	ct := thttp.NewFastHTTPClientTransport()
+	_, err := ct.RoundTrip(ctx, nil, transport.WithDialAddress("127.0.0.1:1"))
+	require.ErrorContains(t, err, "DecorateRequest returned nil")
+}
+
+type transportHandlerFunc func(context.Context, []byte) ([]byte, error)
+
+func (f transportHandlerFunc) Handle(ctx context.Context, req []byte) ([]byte, error) {
+	return f(ctx, req)
+}

--- a/transport/client_transport_options.go
+++ b/transport/client_transport_options.go
@@ -16,6 +16,7 @@ package transport
 // ClientTransportOptions is the client transport options.
 type ClientTransportOptions struct {
 	DisableHTTPEncodeTransInfoBase64 bool
+	MaxRedirectsCount                int
 }
 
 // ClientTransportOption modifies the ClientTransportOptions.
@@ -26,5 +27,13 @@ type ClientTransportOption func(*ClientTransportOptions)
 func WithDisableEncodeTransInfoBase64() ClientTransportOption {
 	return func(opts *ClientTransportOptions) {
 		opts.DisableHTTPEncodeTransInfoBase64 = true
+	}
+}
+
+// WithMaxRedirectsCount returns a ClientTransportOption which customizes the
+// maximum redirects count for FastHTTP client transport.
+func WithMaxRedirectsCount(c int) ClientTransportOption {
+	return func(opts *ClientTransportOptions) {
+		opts.MaxRedirectsCount = c
 	}
 }

--- a/transport/client_transport_test.go
+++ b/transport/client_transport_test.go
@@ -796,3 +796,9 @@ func TestWithDisableEncodeTransInfoBase64(t *testing.T) {
 	transport.WithDisableEncodeTransInfoBase64()(opts)
 	assert.Equal(t, true, opts.DisableHTTPEncodeTransInfoBase64)
 }
+
+func TestWithMaxRedirectsCount(t *testing.T) {
+	opts := &transport.ClientTransportOptions{}
+	transport.WithMaxRedirectsCount(3)(opts)
+	assert.Equal(t, 3, opts.MaxRedirectsCount)
+}


### PR DESCRIPTION
## Summary
- add FastHTTP client/server transport and codec registrations for `fasthttp` and `fasthttp_no_protocol`
- add FastHTTP client proxy helpers, RequestCtx service handlers, and a redirect-count transport option
- document basic FastHTTP usage and add targeted codec/client/transport tests

## Tests
- go test ./http -count=1
- go test ./http -coverprofile=<cover.out> -count=1 (http package coverage: 88.0%)
- go test ./transport -count=1
- go test ./... -count=1
