### PR TITLE
all: internalize protocol names

### DIFF
--- a/admin/admin.go
+++ b/admin/admin.go
@@ -34,6 +34,7 @@ import (
 	"trpc.group/trpc-go/trpc-go/config"
 	"trpc.group/trpc-go/trpc-go/errs"
 	"trpc.group/trpc-go/trpc-go/healthcheck"
+	"trpc.group/trpc-go/trpc-go/internal/protocol"
 	"trpc.group/trpc-go/trpc-go/log"
 	"trpc.group/trpc-go/trpc-go/rpcz"
 	"trpc.group/trpc-go/trpc-go/transport"
@@ -180,7 +181,7 @@ func (s *Server) Serve() error {
 		return errors.New("admin service does not support tls")
 	}
 
-	const network = "tcp"
+	const network = protocol.TCP
 	ln, err := s.listen(network, cfg.addr)
 	if err != nil {
 		return err

--- a/client/client.go
+++ b/client/client.go
@@ -26,6 +26,7 @@ import (
 	"trpc.group/trpc-go/trpc-go/filter"
 	"trpc.group/trpc-go/trpc-go/internal/attachment"
 	icodec "trpc.group/trpc-go/trpc-go/internal/codec"
+	"trpc.group/trpc-go/trpc-go/internal/protocol"
 	"trpc.group/trpc-go/trpc-go/internal/report"
 	"trpc.group/trpc-go/trpc-go/naming/registry"
 	"trpc.group/trpc-go/trpc-go/naming/selector"
@@ -517,7 +518,7 @@ func ensureMsgRemoteAddr(
 	}
 
 	switch network {
-	case "tcp", "tcp4", "tcp6", "udp", "udp4", "udp6":
+	case protocol.TCP, protocol.TCP4, protocol.TCP6, protocol.UDP, protocol.UDP4, protocol.UDP6:
 		// Check if address can be parsed as an ip.
 		host, _, err := net.SplitHostPort(address)
 		if err != nil || net.ParseIP(host) == nil {
@@ -526,14 +527,14 @@ func ensureMsgRemoteAddr(
 	}
 	var addr net.Addr
 	switch network {
-	case "tcp", "tcp4", "tcp6":
+	case protocol.TCP, protocol.TCP4, protocol.TCP6:
 		addr, _ = net.ResolveTCPAddr(network, address)
-	case "udp", "udp4", "udp6":
+	case protocol.UDP, protocol.UDP4, protocol.UDP6:
 		addr, _ = net.ResolveUDPAddr(network, address)
-	case "unix":
+	case protocol.UNIX:
 		addr, _ = net.ResolveUnixAddr(network, address)
 	default:
-		addr, _ = net.ResolveTCPAddr("tcp4", address)
+		addr, _ = net.ResolveTCPAddr(protocol.TCP4, address)
 	}
 	msg.WithRemoteAddr(addr)
 }

--- a/client/client_linux.go
+++ b/client/client_linux.go
@@ -4,6 +4,7 @@
 package client
 
 import (
+	"trpc.group/trpc-go/trpc-go/internal/protocol"
 	"trpc.group/trpc-go/trpc-go/log"
 	"trpc.group/trpc-go/trpc-go/transport"
 	"trpc.group/trpc-go/trpc-go/transport/tnet"
@@ -25,10 +26,10 @@ func attemptSwitchingTransport(o *Options) transport.ClientTransport {
 
 func check(o *Options) bool {
 	// Only use tnet transport with TCP and trpc.
-	return (o.Network == "tcp" ||
-		o.Network == "tcp4" ||
-		o.Network == "tcp6") &&
-		o.Protocol == "trpc"
+	return (o.Network == protocol.TCP ||
+		o.Network == protocol.TCP4 ||
+		o.Network == protocol.TCP6) &&
+		o.Protocol == protocol.TRPC
 }
 
 func cheer(o *Options) {

--- a/client/config.go
+++ b/client/config.go
@@ -22,6 +22,7 @@ import (
 	"trpc.group/trpc-go/trpc-go/config"
 	"trpc.group/trpc-go/trpc-go/filter"
 	icodec "trpc.group/trpc-go/trpc-go/internal/codec"
+	"trpc.group/trpc-go/trpc-go/internal/protocol"
 	"trpc.group/trpc-go/trpc-go/naming/circuitbreaker"
 	"trpc.group/trpc-go/trpc-go/naming/discovery"
 	"trpc.group/trpc-go/trpc-go/naming/loadbalance"
@@ -208,8 +209,8 @@ var (
 	DefaultSelectorFilterName = "selector"
 
 	defaultBackendConf = &BackendConfig{
-		Network:  "tcp",
-		Protocol: "trpc",
+		Network:  protocol.TCP,
+		Protocol: protocol.TRPC,
 	}
 	defaultBackendOptions *Options
 

--- a/codec.go
+++ b/codec.go
@@ -27,6 +27,7 @@ import (
 	"trpc.group/trpc-go/trpc-go/codec"
 	"trpc.group/trpc-go/trpc-go/errs"
 	"trpc.group/trpc-go/trpc-go/internal/attachment"
+	"trpc.group/trpc-go/trpc-go/internal/protocol"
 	"trpc.group/trpc-go/trpc-go/transport"
 
 	"google.golang.org/protobuf/proto"
@@ -75,7 +76,7 @@ const (
 	UserIP      = "trpc-user-ip"    // user ip
 	EnvTransfer = "trpc-env"        // env info
 
-	ProtocolName = "trpc" // protocol name
+	ProtocolName = protocol.TRPC // protocol name
 )
 
 // trpc protocol codec

--- a/config.go
+++ b/config.go
@@ -31,6 +31,7 @@ import (
 	"trpc.group/trpc-go/trpc-go/client"
 	"trpc.group/trpc-go/trpc-go/codec"
 	"trpc.group/trpc-go/trpc-go/errs"
+	"trpc.group/trpc-go/trpc-go/internal/protocol"
 	"trpc.group/trpc-go/trpc-go/internal/rand"
 	"trpc.group/trpc-go/trpc-go/plugin"
 	"trpc.group/trpc-go/trpc-go/rpcz"
@@ -566,10 +567,10 @@ func init() {
 func defaultConfig() *Config {
 	cfg := &Config{}
 	cfg.Global.EnableSet = "N"
-	cfg.Server.Network = "tcp"
-	cfg.Server.Protocol = "trpc"
-	cfg.Client.Network = "tcp"
-	cfg.Client.Protocol = "trpc"
+	cfg.Server.Network = protocol.TCP
+	cfg.Server.Protocol = protocol.TRPC
+	cfg.Client.Network = protocol.TCP
+	cfg.Client.Protocol = protocol.TRPC
 	return cfg
 }
 

--- a/http/client.go
+++ b/http/client.go
@@ -21,6 +21,7 @@ import (
 	"trpc.group/trpc-go/trpc-go/client"
 	"trpc.group/trpc-go/trpc-go/codec"
 	"trpc.group/trpc-go/trpc-go/errs"
+	"trpc.group/trpc-go/trpc-go/internal/protocol"
 )
 
 // Client provides the HTTP client interface.
@@ -52,7 +53,7 @@ var NewClientProxy = func(name string, opts ...client.Option) Client {
 		client:      client.DefaultClient,
 	}
 	c.opts = make([]client.Option, 0, len(opts)+1)
-	c.opts = append(c.opts, client.WithProtocol("http"))
+	c.opts = append(c.opts, client.WithProtocol(protocol.HTTP))
 	c.opts = append(c.opts, opts...)
 	return c
 }
@@ -65,7 +66,7 @@ func NewStdHTTPClient(name string, opts ...client.Option) *http.Client {
 		client:      client.DefaultClient,
 	}
 	c.opts = make([]client.Option, 0, len(opts)+1)
-	c.opts = append(c.opts, client.WithProtocol("http"))
+	c.opts = append(c.opts, client.WithProtocol(protocol.HTTP))
 	c.opts = append(c.opts, opts...)
 	return &http.Client{Transport: c}
 }

--- a/http/codec.go
+++ b/http/codec.go
@@ -33,6 +33,7 @@ import (
 	"trpc.group/trpc-go/trpc-go/codec"
 	"trpc.group/trpc-go/trpc-go/errs"
 	icodec "trpc.group/trpc-go/trpc-go/internal/codec"
+	"trpc.group/trpc-go/trpc-go/internal/protocol"
 )
 
 // Constants of header keys related to trpc.
@@ -129,11 +130,11 @@ func RegisterStatus[T errs.ErrCode](code T, httpStatus int) {
 }
 
 func init() {
-	codec.Register("http", DefaultServerCodec, DefaultClientCodec)
-	codec.Register("http2", DefaultServerCodec, DefaultClientCodec)
+	codec.Register(protocol.HTTP, DefaultServerCodec, DefaultClientCodec)
+	codec.Register(protocol.HTTP2, DefaultServerCodec, DefaultClientCodec)
 	// Support no protocol file custom routing and feature isolation.
-	codec.Register("http_no_protocol", DefaultNoProtocolServerCodec, DefaultClientCodec)
-	codec.Register("http2_no_protocol", DefaultNoProtocolServerCodec, DefaultClientCodec)
+	codec.Register(protocol.HTTPNoProtocol, DefaultNoProtocolServerCodec, DefaultClientCodec)
+	codec.Register(protocol.HTTP2NoProtocol, DefaultNoProtocolServerCodec, DefaultClientCodec)
 }
 
 var (
@@ -719,7 +720,7 @@ func (c *ClientCodec) Decode(msg codec.Msg, _ []byte) ([]byte, error) {
 			e := &errs.Error{
 				Type: errs.ErrorTypeCalleeFramework,
 				Code: trpcpb.TrpcRetCode(i),
-				Desc: "trpc",
+				Desc: protocol.TRPC,
 				Msg:  rsp.Header.Get(TrpcErrorMessage),
 			}
 			msg.WithClientRspErr(e)
@@ -737,7 +738,7 @@ func (c *ClientCodec) Decode(msg codec.Msg, _ []byte) ([]byte, error) {
 		e := &errs.Error{
 			Type: errs.ErrorTypeBusiness,
 			Code: trpcpb.TrpcRetCode(rsp.StatusCode),
-			Desc: "http",
+			Desc: protocol.HTTP,
 			Msg:  fmt.Sprintf("http client codec StatusCode: %s, body: %q", http.StatusText(rsp.StatusCode), body),
 		}
 		msg.WithClientRspErr(e)

--- a/http/restful_server_transport.go
+++ b/http/restful_server_transport.go
@@ -27,6 +27,7 @@ import (
 	"github.com/valyala/fasthttp"
 	"golang.org/x/net/http2"
 	"golang.org/x/net/http2/h2c"
+	"trpc.group/trpc-go/trpc-go/internal/protocol"
 	"trpc.group/trpc-go/trpc-go/internal/reuseport"
 	itls "trpc.group/trpc-go/trpc-go/internal/tls"
 	trpcpb "trpc.group/trpc/trpc-protocol/pb/go/trpc"
@@ -130,7 +131,7 @@ func NewRESTServerTransport(basedOnFastHTTP bool, opt ...transport.ServerTranspo
 // ListenAndServe implements interface of transport.ServerTransport.
 func (st *RESTServerTransport) ListenAndServe(ctx context.Context, opt ...transport.ListenServeOption) error {
 	opts := &transport.ListenServeOptions{
-		Network: "tcp",
+		Network: protocol.TCP,
 	}
 	for _, o := range opt {
 		o(opts)

--- a/http/transport.go
+++ b/http/transport.go
@@ -38,6 +38,7 @@ import (
 	"golang.org/x/net/http2"
 	"golang.org/x/net/http2/h2c"
 	icontext "trpc.group/trpc-go/trpc-go/internal/context"
+	"trpc.group/trpc-go/trpc-go/internal/protocol"
 	"trpc.group/trpc-go/trpc-go/internal/reuseport"
 	trpcpb "trpc.group/trpc/trpc-protocol/pb/go/trpc"
 
@@ -55,14 +56,14 @@ func init() {
 	DefaultServerTransport = st
 	DefaultHTTP2ServerTransport = st
 	// Server transport (protocol file service).
-	transport.RegisterServerTransport("http", st)
-	transport.RegisterServerTransport("http2", st)
+	transport.RegisterServerTransport(protocol.HTTP, st)
+	transport.RegisterServerTransport(protocol.HTTP2, st)
 	// Server transport (no protocol file service).
-	transport.RegisterServerTransport("http_no_protocol", st)
-	transport.RegisterServerTransport("http2_no_protocol", st)
+	transport.RegisterServerTransport(protocol.HTTPNoProtocol, st)
+	transport.RegisterServerTransport(protocol.HTTP2NoProtocol, st)
 	// Client transport.
-	transport.RegisterClientTransport("http", DefaultClientTransport)
-	transport.RegisterClientTransport("http2", DefaultHTTP2ClientTransport)
+	transport.RegisterClientTransport(protocol.HTTP, DefaultClientTransport)
+	transport.RegisterClientTransport(protocol.HTTP2, DefaultHTTP2ClientTransport)
 }
 
 // DefaultServerTransport is the default server http transport.
@@ -97,7 +98,7 @@ func NewServerTransport(
 // ListenAndServe handles configuration.
 func (t *ServerTransport) ListenAndServe(ctx context.Context, opt ...transport.ListenServeOption) error {
 	opts := &transport.ListenServeOptions{
-		Network: "tcp",
+		Network: protocol.TCP,
 	}
 	for _, o := range opt {
 		o(opts)
@@ -139,7 +140,7 @@ func (t *ServerTransport) listenAndServeHTTP(ctx context.Context, opts *transpor
 		if ok {
 			msg.WithLocalAddr(localAddr)
 		}
-		raddr, _ := net.ResolveTCPAddr("tcp", h.Request.RemoteAddr)
+		raddr, _ := net.ResolveTCPAddr(protocol.TCP, h.Request.RemoteAddr)
 		msg.WithRemoteAddr(raddr)
 		_, err := opts.Handler.Handle(ctx, emptyBuf)
 		if err != nil {
@@ -461,9 +462,9 @@ func (ct *ClientTransport) newRequest(reqHeader *ClientReqHeader,
 	scheme := reqHeader.Schema
 	if scheme == "" {
 		if len(opts.CACertFile) > 0 || strings.HasSuffix(opts.Address, ":443") {
-			scheme = "https"
+			scheme = protocol.HTTPS
 		} else {
-			scheme = "http"
+			scheme = protocol.HTTP
 		}
 	}
 

--- a/internal/protocol/protocol.go
+++ b/internal/protocol/protocol.go
@@ -1,0 +1,42 @@
+// Package protocol provides internal protocol and network name constants.
+package protocol
+
+const (
+	// HTTP is the HTTP RPC protocol name.
+	HTTP = "http"
+	// HTTP2 is the HTTP/2 RPC protocol name.
+	HTTP2 = "http2"
+	// HTTPS is the HTTPS RPC protocol name.
+	HTTPS = "https"
+	// HTTPNoProtocol is the standard HTTP service protocol name.
+	HTTPNoProtocol = "http_no_protocol"
+	// HTTP2NoProtocol is the standard HTTP/2 service protocol name.
+	HTTP2NoProtocol = "http2_no_protocol"
+	// HTTPSNoProtocol is the standard HTTPS service protocol name.
+	HTTPSNoProtocol = "https_no_protocol"
+	// FastHTTP is the FastHTTP RPC protocol name.
+	FastHTTP = "fasthttp"
+	// FastHTTPNoProtocol is the standard FastHTTP service protocol name.
+	FastHTTPNoProtocol = "fasthttp_no_protocol"
+	// TRPC is the tRPC protocol name.
+	TRPC = "trpc"
+	// TNET is the tnet transport name.
+	TNET = "tnet"
+)
+
+const (
+	// TCP is the TCP network name.
+	TCP = "tcp"
+	// TCP4 is the TCP over IPv4 network name.
+	TCP4 = "tcp4"
+	// TCP6 is the TCP over IPv6 network name.
+	TCP6 = "tcp6"
+	// UDP is the UDP network name.
+	UDP = "udp"
+	// UDP4 is the UDP over IPv4 network name.
+	UDP4 = "udp4"
+	// UDP6 is the UDP over IPv6 network name.
+	UDP6 = "udp6"
+	// UNIX is the Unix domain socket network name.
+	UNIX = "unix"
+)

--- a/internal/reuseport/reuseport.go
+++ b/internal/reuseport/reuseport.go
@@ -24,6 +24,8 @@ import (
 	"net"
 	"os"
 	"syscall"
+
+	"trpc.group/trpc-go/trpc-go/internal/protocol"
 )
 
 const fileNameTemplate = "reuseport.%d.%s.%s"
@@ -34,9 +36,9 @@ var errUnsupportedProtocol = errors.New("only tcp, tcp4, tcp6, udp, udp4, udp6 a
 // of syscall.Sockaddr: syscall.SockaddrInet4 or syscall.SockaddrInet6.
 func getSockaddr(proto, addr string) (sa syscall.Sockaddr, soType int, err error) {
 	switch proto {
-	case "tcp", "tcp4", "tcp6":
+	case protocol.TCP, protocol.TCP4, protocol.TCP6:
 		return getTCPSockaddr(proto, addr)
-	case "udp", "udp4", "udp6":
+	case protocol.UDP, protocol.UDP4, protocol.UDP6:
 		return getUDPSockaddr(proto, addr)
 	default:
 		return nil, -1, errUnsupportedProtocol

--- a/internal/reuseport/tcp.go
+++ b/internal/reuseport/tcp.go
@@ -21,6 +21,8 @@ import (
 	"net"
 	"os"
 	"syscall"
+
+	"trpc.group/trpc-go/trpc-go/internal/protocol"
 )
 
 var (
@@ -84,9 +86,9 @@ func getTCPSockaddr(proto, addr string) (sa syscall.Sockaddr, soType int, err er
 		return nil, -1, err
 	}
 	switch tcpVersion {
-	case "tcp":
+	case protocol.TCP:
 		return &syscall.SockaddrInet4{Port: tcp.Port}, syscall.AF_INET, nil
-	case "tcp4":
+	case protocol.TCP4:
 		return getTCP4Sockaddr(tcp)
 	default:
 		// must be "tcp6"
@@ -100,15 +102,15 @@ func determineTCPProto(proto string, ip *net.TCPAddr) (string, error) {
 	// the protocol given to us by the caller.
 
 	if ip.IP.To4() != nil {
-		return "tcp4", nil
+		return protocol.TCP4, nil
 	}
 
 	if ip.IP.To16() != nil {
-		return "tcp6", nil
+		return protocol.TCP6, nil
 	}
 
 	switch proto {
-	case "tcp", "tcp4", "tcp6":
+	case protocol.TCP, protocol.TCP4, protocol.TCP6:
 		return proto, nil
 	default:
 		return "", errUnsupportedTCPProtocol

--- a/internal/reuseport/udp.go
+++ b/internal/reuseport/udp.go
@@ -21,6 +21,8 @@ import (
 	"net"
 	"os"
 	"syscall"
+
+	"trpc.group/trpc-go/trpc-go/internal/protocol"
 )
 
 var errUnsupportedUDPProtocol = errors.New("only udp, udp4, udp6 are supported")
@@ -82,9 +84,9 @@ func getUDPSockaddr(proto, addr string) (sa syscall.Sockaddr, soType int, err er
 	}
 
 	switch udpVersion {
-	case "udp":
+	case protocol.UDP:
 		return &syscall.SockaddrInet4{Port: udp.Port}, syscall.AF_INET, nil
-	case "udp4":
+	case protocol.UDP4:
 		return getUDP4Sockaddr(udp)
 	default:
 		// must be "udp6"
@@ -98,15 +100,15 @@ func determineUDPProto(proto string, ip *net.UDPAddr) (string, error) {
 	// the protocol given to us by the caller.
 
 	if ip.IP.To4() != nil {
-		return "udp4", nil
+		return protocol.UDP4, nil
 	}
 
 	if ip.IP.To16() != nil {
-		return "udp6", nil
+		return protocol.UDP6, nil
 	}
 
 	switch proto {
-	case "udp", "udp4", "udp6":
+	case protocol.UDP, protocol.UDP4, protocol.UDP6:
 		return proto, nil
 	default:
 		return "", errUnsupportedUDPProtocol

--- a/naming/selector/passthrough.go
+++ b/naming/selector/passthrough.go
@@ -16,12 +16,13 @@ package selector
 import (
 	"time"
 
+	"trpc.group/trpc-go/trpc-go/internal/protocol"
 	"trpc.group/trpc-go/trpc-go/naming/registry"
 )
 
 func init() {
 	Register("passthrough", NewPassthroughSelector()) // passthrough://temp.sock
-	Register("unix", NewPassthroughSelector())        // unix://temp.sock
+	Register(protocol.UNIX, NewPassthroughSelector()) // unix://temp.sock
 }
 
 // passthroughSelector is a selector simply passthrough serviceName.

--- a/server/service_linux.go
+++ b/server/service_linux.go
@@ -4,6 +4,7 @@
 package server
 
 import (
+	"trpc.group/trpc-go/trpc-go/internal/protocol"
 	"trpc.group/trpc-go/trpc-go/log"
 	"trpc.group/trpc-go/trpc-go/transport"
 	"trpc.group/trpc-go/trpc-go/transport/tnet"
@@ -14,10 +15,10 @@ func attemptSwitchingTransport(o *Options) transport.ServerTransport {
 	// attempt to switch to the tnet transport.
 	if o.Transport == nil {
 		// Only use tnet transport with TCP and trpc.
-		if (o.network == "tcp" ||
-			o.network == "tcp4" ||
-			o.network == "tcp6") &&
-			o.protocol == "trpc" {
+		if (o.network == protocol.TCP ||
+			o.network == protocol.TCP4 ||
+			o.network == protocol.TCP6) &&
+			o.protocol == protocol.TRPC {
 			log.Infof("service %s with network %s and protocol %s is empowered with tnet! 🤩 "+
 				"you can set 'transport: go-net' in your trpc_go.yaml's service configuration "+
 				"to switch to the golang net framework",

--- a/test/go.mod
+++ b/test/go.mod
@@ -33,8 +33,10 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421 // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/panjf2000/ants/v2 v2.4.6 // indirect
+	github.com/pierrec/lz4/v4 v4.1.21 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/r3labs/sse/v2 v2.10.0 // indirect
 	github.com/spf13/cast v1.3.1 // indirect
 	github.com/valyala/bytebufferpool v1.0.0 // indirect
 	github.com/valyala/fasthttp v1.43.0 // indirect
@@ -43,5 +45,6 @@ require (
 	go.uber.org/multierr v1.10.0 // indirect
 	golang.org/x/sys v0.13.0 // indirect
 	golang.org/x/text v0.13.0 // indirect
+	gopkg.in/cenkalti/backoff.v1 v1.1.0 // indirect
 	trpc.group/trpc-go/tnet v1.0.1 // indirect
 )

--- a/test/go.sum
+++ b/test/go.sum
@@ -49,10 +49,14 @@ github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9G
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/panjf2000/ants/v2 v2.4.6 h1:drmj9mcygn2gawZ155dRbo+NfXEfAssjZNU1qoIb4gQ=
 github.com/panjf2000/ants/v2 v2.4.6/go.mod h1:f6F0NZVFsGCp5A7QW/Zj/m92atWwOkY0OIhFxRNFr4A=
+github.com/pierrec/lz4/v4 v4.1.21 h1:yOVMLb6qSIDP67pl/5F7RepeKYu/VmTyEXvuMI5d9mQ=
+github.com/pierrec/lz4/v4 v4.1.21/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFuRQyBid4=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/r3labs/sse/v2 v2.10.0 h1:hFEkLLFY4LDifoHdiCN/LlGBAdVJYsANaLqNYa1l/v0=
+github.com/r3labs/sse/v2 v2.10.0/go.mod h1:Igau6Whc+F17QUgML1fYe1VPZzTV6EMCnYktEmkNJ7I=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/spf13/cast v1.3.1 h1:nFm6S0SMdyzrzcmThSipiEubIDy8WEXKNZ0UOgiRpng=
 github.com/spf13/cast v1.3.1/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
@@ -60,6 +64,7 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6KllzawFIhcdPw=
@@ -84,6 +89,7 @@ golang.org/x/mod v0.0.0-20190513183733-4bf6d317e70e/go.mod h1:mXi4GBBbnImb6dmsKG
 golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/net v0.0.0-20191116160921-f9c825593386/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20220906165146-f3363e06e74c/go.mod h1:YDH+HFinaLZZlnHAfSS6ZXJJ9M9t4Dl22yv3iI2vPwk=
 golang.org/x/net v0.17.0 h1:pVaXccu2ozPjCXewfr1S7xza/zcXTity9cCdXQYSjIM=
@@ -116,12 +122,15 @@ google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp0
 google.golang.org/protobuf v1.30.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
 google.golang.org/protobuf v1.33.0 h1:uNO2rsAINq/JlFpSdYEKIZ0uKD/R9cpdv0T+yoGwGmI=
 google.golang.org/protobuf v1.33.0/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHhKbcUYpos=
+gopkg.in/cenkalti/backoff.v1 v1.1.0 h1:Arh75ttbsvlpVA7WtVpH4u9h6Zl46xuptxqLxPiSo4Y=
+gopkg.in/cenkalti/backoff.v1 v1.1.0/go.mod h1:J6Vskwqd+OMVJl8C33mmtxTBs2gyzfv7UDAkHu8BrjI=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.7/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt0JzvZhAg=

--- a/transport/client_transport.go
+++ b/transport/client_transport.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 
 	"trpc.group/trpc-go/trpc-go/errs"
+	"trpc.group/trpc-go/trpc-go/internal/protocol"
 	"trpc.group/trpc-go/trpc-go/pool/connpool"
 	"trpc.group/trpc-go/trpc-go/pool/multiplexed"
 )
@@ -80,9 +81,9 @@ func (c *clientTransport) RoundTrip(ctx context.Context, req []byte,
 	}
 
 	switch opts.Network {
-	case "tcp", "tcp4", "tcp6", "unix":
+	case protocol.TCP, protocol.TCP4, protocol.TCP6, protocol.UNIX:
 		return c.tcpRoundTrip(ctx, req, opts)
-	case "udp", "udp4", "udp6":
+	case protocol.UDP, protocol.UDP4, protocol.UDP6:
 		return c.udpRoundTrip(ctx, req, opts)
 	default:
 		return nil, errs.NewFrameError(errs.RetClientConnectFail,

--- a/transport/server_transport.go
+++ b/transport/server_transport.go
@@ -28,6 +28,7 @@ import (
 	"time"
 
 	"github.com/panjf2000/ants/v2"
+	"trpc.group/trpc-go/trpc-go/internal/protocol"
 	"trpc.group/trpc-go/trpc-go/internal/reuseport"
 
 	itls "trpc.group/trpc-go/trpc-go/internal/tls"
@@ -102,11 +103,11 @@ func (s *serverTransport) ListenAndServe(ctx context.Context, opts ...ListenServ
 	for _, network := range networks {
 		lsopts.Network = network
 		switch lsopts.Network {
-		case "tcp", "tcp4", "tcp6", "unix":
+		case protocol.TCP, protocol.TCP4, protocol.TCP6, protocol.UNIX:
 			if err := s.listenAndServeStream(ctx, lsopts); err != nil {
 				return err
 			}
-		case "udp", "udp4", "udp6":
+		case protocol.UDP, protocol.UDP4, protocol.UDP6:
 			if err := s.listenAndServePacket(ctx, lsopts); err != nil {
 				return err
 			}
@@ -193,7 +194,7 @@ func (s *serverTransport) getTCPListener(opts *ListenServeOptions) (listener net
 	}
 
 	// Reuse port. To speed up IO, the kernel dispatches IO ReadReady events to threads.
-	if s.opts.ReusePort && opts.Network != "unix" {
+	if s.opts.ReusePort && opts.Network != protocol.UNIX {
 		listener, err = reuseport.Listen(opts.Network, opts.Address)
 		if err != nil {
 			return nil, fmt.Errorf("%s reuseport error:%v", opts.Network, err)

--- a/transport/server_transport_tcp.go
+++ b/transport/server_transport_tcp.go
@@ -27,6 +27,7 @@ import (
 	"trpc.group/trpc-go/trpc-go/codec"
 	"trpc.group/trpc-go/trpc-go/errs"
 	"trpc.group/trpc-go/trpc-go/internal/addrutil"
+	"trpc.group/trpc-go/trpc-go/internal/protocol"
 	"trpc.group/trpc-go/trpc-go/internal/report"
 	"trpc.group/trpc-go/trpc-go/internal/writev"
 	"trpc.group/trpc-go/trpc-go/log"
@@ -187,7 +188,7 @@ func (c *tcpconn) close() {
 		e := &errs.Error{
 			Type: errs.ErrorTypeFramework,
 			Code: errs.RetServerSystemErr,
-			Desc: "trpc",
+			Desc: protocol.TRPC,
 			Msg:  "Server connection closed",
 		}
 		msg.WithServerRspErr(e)

--- a/transport/tnet/client_transport.go
+++ b/transport/tnet/client_transport.go
@@ -25,6 +25,7 @@ import (
 	"trpc.group/trpc-go/tnet/tls"
 
 	"trpc.group/trpc-go/trpc-go/errs"
+	"trpc.group/trpc-go/trpc-go/internal/protocol"
 	intertls "trpc.group/trpc-go/trpc-go/internal/tls"
 	"trpc.group/trpc-go/trpc-go/log"
 	"trpc.group/trpc-go/trpc-go/pool/connpool"
@@ -100,7 +101,7 @@ func (c *clientTransport) switchNetworkToRoundTrip(
 		return c.multiplex(ctx, req, option)
 	}
 	switch option.Network {
-	case "tcp", "tcp4", "tcp6":
+	case protocol.TCP, protocol.TCP4, protocol.TCP6:
 		return c.tcpRoundTrip(ctx, req, option)
 	default:
 		return nil, errs.NewFrameError(errs.RetClientConnectFail,
@@ -190,7 +191,7 @@ func validateTnetTLSConn(conn net.Conn) bool {
 
 func canUseTnet(opts *transport.RoundTripOptions) error {
 	switch opts.Network {
-	case "tcp", "tcp4", "tcp6":
+	case protocol.TCP, protocol.TCP4, protocol.TCP6:
 	default:
 		return fmt.Errorf("tnet doesn't support network [%s]", opts.Network)
 	}

--- a/transport/tnet/server_transport.go
+++ b/transport/tnet/server_transport.go
@@ -29,11 +29,12 @@ import (
 	"trpc.group/trpc-go/trpc-go/codec"
 	"trpc.group/trpc-go/trpc-go/errs"
 	"trpc.group/trpc-go/trpc-go/internal/addrutil"
+	"trpc.group/trpc-go/trpc-go/internal/protocol"
 	"trpc.group/trpc-go/trpc-go/log"
 	"trpc.group/trpc-go/trpc-go/transport"
 )
 
-const transportName = "tnet"
+const transportName = protocol.TNET
 
 func init() {
 	transport.RegisterServerTransport(transportName, DefaultServerTransport)
@@ -108,7 +109,7 @@ func (s *serverTransport) Close(ctx context.Context) {
 
 func (s *serverTransport) switchNetworkToServe(ctx context.Context, opts *transport.ListenServeOptions) error {
 	switch opts.Network {
-	case "tcp", "tcp4", "tcp6":
+	case protocol.TCP, protocol.TCP4, protocol.TCP6:
 		if err := s.listenAndServeTCP(ctx, opts); err != nil {
 			return err
 		}

--- a/transport/tnet/server_transport_tcp.go
+++ b/transport/tnet/server_transport_tcp.go
@@ -35,6 +35,7 @@ import (
 	"trpc.group/trpc-go/trpc-go/codec"
 	"trpc.group/trpc-go/trpc-go/errs"
 	"trpc.group/trpc-go/trpc-go/internal/addrutil"
+	"trpc.group/trpc-go/trpc-go/internal/protocol"
 	"trpc.group/trpc-go/trpc-go/internal/report"
 	intertls "trpc.group/trpc-go/trpc-go/internal/tls"
 	"trpc.group/trpc-go/trpc-go/log"
@@ -249,7 +250,7 @@ func (s *serverTransport) onConnClosed(conn net.Conn, handler transport.Handler)
 	e := &errs.Error{
 		Type: errs.ErrorTypeFramework,
 		Code: errs.RetServerSystemErr,
-		Desc: "trpc",
+		Desc: protocol.TRPC,
 		Msg:  "Server connection closed",
 	}
 	msg.WithServerRspErr(e)


### PR DESCRIPTION
## Summary

- add internal protocol and network name constants
- replace framework-internal magic strings with those constants
- sync the integration test module dependencies required by the current root module

## Compatibility

This keeps the public tRPC protocol types unchanged. The framework still uses `trpc.group/trpc/trpc-protocol/pb/go/trpc` for `RequestProtocol`, `ResponseProtocol`, and `TrpcRetCode`.

The `trpc-protocol` dependency is intentionally not upgraded here. Version `v1.0.1` currently pulls `google.golang.org/protobuf v1.36.6`, which declares `go 1.22`; the public module still declares `go 1.18`.

## Tests

- `go test ./...`
- `go test -v -coverprofile=coverage.out ./...`
- `go test ./... -run ^ -count=0` in the `test` module

The full `test` module end-to-end suite runs locally after the dependency sync, but still has existing HTTPS/TLS and graceful-restart failures unrelated to this change.
