### PR TITLE
client: support connection prewarming

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -39,6 +39,13 @@ type Client interface {
 	Invoke(ctx context.Context, reqBody interface{}, rspBody interface{}, opt ...Option) error
 }
 
+// InitializableClient is a client that supports explicit initialization.
+type InitializableClient interface {
+	Client
+	// Init initializes the client with the provided options.
+	Init(ctx context.Context, opt ...Option) error
+}
+
 // DefaultClient is the default global client.
 // It's thread-safe.
 var DefaultClient = New()

--- a/client/config.go
+++ b/client/config.go
@@ -82,6 +82,15 @@ type BackendConfig struct {
 
 	// Report any error to the selector if this value is true.
 	ReportAnyErrToSelector bool `yaml:"report_any_err_to_selector"`
+
+	// PreWarm specifies the configuration for client connection prewarming.
+	PreWarm PreWarmConfig `yaml:"pre_warm,omitempty"`
+}
+
+// PreWarmConfig defines the configuration for client connection prewarming.
+type PreWarmConfig struct {
+	ConnsPerNode *int           `yaml:"conns_per_node,omitempty"`
+	Timeout      *time.Duration `yaml:"timeout,omitempty"`
 }
 
 // genOptions generates options for each RPC from BackendConfig.
@@ -113,6 +122,7 @@ func (cfg *BackendConfig) genOptions() (*Options, error) {
 	if cfg.TLSCertProvider != "" {
 		WithCertProvider(cfg.TLSCertProvider)(opts)
 	}
+	cfg.setPreWarm(opts)
 	if cfg.Protocol != "" && opts.Codec == nil {
 		return nil, fmt.Errorf("codec %s not exists", cfg.Protocol)
 	}
@@ -200,6 +210,17 @@ func (cfg *BackendConfig) setNamingOptions(opts *Options) error {
 		opts.SelectOptions = append(opts.SelectOptions, selector.WithCircuitBreaker(cb))
 	}
 	return nil
+}
+
+func (cfg *BackendConfig) setPreWarm(opts *Options) {
+	if cfg.PreWarm.ConnsPerNode == nil {
+		return
+	}
+	preWarmOpts := transport.PreWarmOptions{ConnsPerNode: *cfg.PreWarm.ConnsPerNode}
+	if cfg.PreWarm.Timeout != nil {
+		preWarmOpts.Timeout = *cfg.PreWarm.Timeout
+	}
+	opts.CallOptions = append(opts.CallOptions, transport.WithPreWarm(preWarmOpts))
 }
 
 var (

--- a/client/config_test.go
+++ b/client/config_test.go
@@ -245,6 +245,82 @@ transport: test-transport
 	})
 }
 
+func TestConfigPreWarm(t *testing.T) {
+	tests := []struct {
+		name         string
+		config       string
+		connsPerNode int
+		timeout      time.Duration
+		isPreWarmNil bool
+	}{
+		{
+			name: "prewarm",
+			config: `
+pre_warm:
+  conns_per_node: 2
+  timeout: 1000ms
+`,
+			connsPerNode: 2,
+			timeout:      time.Second,
+		},
+		{
+			name: "prewarm without timeout",
+			config: `
+pre_warm:
+  conns_per_node: 1
+`,
+			connsPerNode: 1,
+		},
+		{
+			name: "prewarm without connections",
+			config: `
+pre_warm:
+`,
+			isPreWarmNil: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var cfg client.BackendConfig
+			require.Nil(t, yaml.Unmarshal([]byte(tt.config), &cfg))
+			require.Nil(t, client.RegisterClientConfig("trpc.test.prewarm."+tt.name, &cfg))
+			opts := client.Config("trpc.test.prewarm." + tt.name)
+			roundTripOpts := &transport.RoundTripOptions{}
+			genOpts, err := optsForBackendConfig(opts)
+			require.NoError(t, err)
+			for _, o := range genOpts.CallOptions {
+				o(roundTripOpts)
+			}
+			if tt.isPreWarmNil {
+				require.Nil(t, roundTripOpts.PreWarm)
+				return
+			}
+			require.NotNil(t, roundTripOpts.PreWarm)
+			require.Equal(t, tt.connsPerNode, roundTripOpts.PreWarm.ConnsPerNode)
+			require.Equal(t, tt.timeout, roundTripOpts.PreWarm.Timeout)
+		})
+	}
+}
+
+func optsForBackendConfig(cfg *client.BackendConfig) (*client.Options, error) {
+	const callee = "trpc.test.prewarm.generated"
+	if err := client.RegisterClientConfig(callee, cfg); err != nil {
+		return nil, err
+	}
+	ctx, msg := codec.EnsureMessage(context.Background())
+	msg.WithCalleeServiceName(callee)
+	ch := make(chan *client.Options, 1)
+	err := client.New().Invoke(ctx, nil, nil, client.WithFilter(
+		func(ctx context.Context, _, _ interface{}, _ filter.ClientHandleFunc) error {
+			ch <- client.OptionsFromContext(ctx)
+			return nil
+		}))
+	if err != nil {
+		return nil, err
+	}
+	return <-ch, nil
+}
+
 func TestConfigStreamFilter(t *testing.T) {
 	filterName := "sf1"
 	cfg := &client.BackendConfig{}

--- a/client/options.go
+++ b/client/options.go
@@ -600,6 +600,14 @@ func WithShouldErrReportToSelector(f func(error) bool) Option {
 	}
 }
 
+// WithPreWarm returns an Option that sets prewarm options.
+// This option is intended for client initialization.
+func WithPreWarm(p transport.PreWarmOptions) Option {
+	return func(o *Options) {
+		o.CallOptions = append(o.CallOptions, transport.WithPreWarm(p))
+	}
+}
+
 type optionsKey struct{}
 
 func contextWithOptions(ctx context.Context, opts *Options) context.Context {

--- a/client/pre_warm.go
+++ b/client/pre_warm.go
@@ -1,0 +1,122 @@
+package client
+
+import (
+	"context"
+	"fmt"
+
+	"trpc.group/trpc-go/trpc-go/codec"
+	"trpc.group/trpc-go/trpc-go/errs"
+	"trpc.group/trpc-go/trpc-go/internal/prewarm"
+	"trpc.group/trpc-go/trpc-go/naming/discovery"
+	"trpc.group/trpc-go/trpc-go/naming/registry"
+	"trpc.group/trpc-go/trpc-go/naming/selector"
+	"trpc.group/trpc-go/trpc-go/naming/servicerouter"
+	"trpc.group/trpc-go/trpc-go/pool/connpool"
+	"trpc.group/trpc-go/trpc-go/pool/multiplexed"
+	"trpc.group/trpc-go/trpc-go/transport"
+)
+
+func (c *client) init(ctx context.Context, opt ...Option) error {
+	ctx, msg := codec.EnsureMessage(ctx)
+	opts, err := c.getOptions(msg, opt...)
+	if err != nil {
+		return err
+	}
+	c.updateMsg(msg, opts)
+	ctx = contextWithOptions(ctx, opts)
+	if !prewarm.Enabled(ctx, opts.CallOptions...) {
+		return nil
+	}
+	if err := c.preWarm(ctx, msg, opts); err != nil {
+		return fmt.Errorf("prewarm: %w", err)
+	}
+	return nil
+}
+
+// Init performs initialization operations on the client using the provided options.
+func (c *client) Init(ctx context.Context, opt ...Option) error {
+	return c.init(ctx, opt...)
+}
+
+func (c *client) preWarm(ctx context.Context, msg codec.Msg, opts *Options) error {
+	roundTripOpts := &transport.RoundTripOptions{
+		Pool:        connpool.DefaultConnectionPool,
+		Multiplexed: multiplexed.DefaultMultiplexedPool,
+		Msg:         codec.Message(ctx),
+	}
+	for _, o := range opts.CallOptions {
+		o(roundTripOpts)
+	}
+	if err := prewarm.ValidateConfig(roundTripOpts); err != nil {
+		return fmt.Errorf("validate prewarm config: %w", err)
+	}
+
+	var cancel context.CancelFunc
+	if _, ok := ctx.Deadline(); !ok && roundTripOpts.PreWarm.Timeout > 0 {
+		ctx, cancel = context.WithTimeout(ctx, roundTripOpts.PreWarm.Timeout)
+		defer cancel()
+	}
+	if err := ctx.Err(); err != nil {
+		return fmt.Errorf("prewarm context error before get node list: %w", err)
+	}
+
+	nodeList, err := c.preWarmNodeList(ctx, msg, opts)
+	if err != nil {
+		return fmt.Errorf("get prewarm node list: %w", err)
+	}
+	if err := prewarm.PreWarm(ctx, nodeList, roundTripOpts); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (c *client) preWarmNodeList(ctx context.Context, msg codec.Msg, opts *Options) ([]*registry.Node, error) {
+	var err error
+	if _, ok := opts.Selector.(*selector.TrpcSelector); ok {
+		var nodeList []*registry.Node
+		nodeList, err = listNodes(ctx, opts)
+		if err == nil && len(nodeList) > 0 {
+			return nodeList, nil
+		}
+	}
+
+	selectOpts := opts.clone()
+	selectOpts.rebuildSliceCapacity()
+	node, selectErr := selectNode(ctx, msg, selectOpts)
+	if selectErr != nil {
+		if err != nil {
+			return nil, fmt.Errorf("%v; fallback select node: %w", err, selectErr)
+		}
+		return nil, selectErr
+	}
+	return []*registry.Node{node}, nil
+}
+
+func listNodes(ctx context.Context, opts *Options) ([]*registry.Node, error) {
+	selectorOpts := selector.Options{
+		Discovery:     discovery.DefaultDiscovery,
+		ServiceRouter: servicerouter.DefaultServiceRouter,
+	}
+	selectOptions := append([]selector.Option{}, opts.SelectOptions...)
+	selectOptions = append(selectOptions, selector.WithContext(ctx))
+	for _, opt := range selectOptions {
+		opt(&selectorOpts)
+	}
+	if selectorOpts.Discovery == nil {
+		return nil, errs.NewFrameError(errs.RetClientRouteErr, "client prewarm: discovery not exists")
+	}
+	nodeList, err := selectorOpts.Discovery.List(opts.endpoint, selectorOpts.DiscoveryOptions...)
+	if err != nil {
+		return nil, errs.NewFrameError(errs.RetClientRouteErr, "client prewarm discovery List: "+err.Error())
+	}
+	if selectorOpts.ServiceRouter != nil {
+		nodeList, err = selectorOpts.ServiceRouter.Filter(opts.endpoint, nodeList, selectorOpts.ServiceRouterOptions...)
+		if err != nil {
+			return nil, errs.NewFrameError(errs.RetClientRouteErr, "client prewarm service router Filter: "+err.Error())
+		}
+	}
+	if len(nodeList) == 0 {
+		return nil, errs.NewFrameError(errs.RetClientRouteErr, "client prewarm: node list is empty")
+	}
+	return nodeList, nil
+}

--- a/client/pre_warm.go
+++ b/client/pre_warm.go
@@ -1,3 +1,16 @@
+//
+//
+// Tencent is pleased to support the open source community by making tRPC available.
+//
+// Copyright (C) 2023 Tencent.
+// All rights reserved.
+//
+// If you have downloaded a copy of the tRPC source code from Tencent,
+// please note that tRPC source code is licensed under the  Apache 2.0 License,
+// A copy of the Apache 2.0 License is included in this file.
+//
+//
+
 package client
 
 import (

--- a/client/pre_warm_test.go
+++ b/client/pre_warm_test.go
@@ -1,3 +1,16 @@
+//
+//
+// Tencent is pleased to support the open source community by making tRPC available.
+//
+// Copyright (C) 2023 Tencent.
+// All rights reserved.
+//
+// If you have downloaded a copy of the tRPC source code from Tencent,
+// please note that tRPC source code is licensed under the  Apache 2.0 License,
+// A copy of the Apache 2.0 License is included in this file.
+//
+//
+
 package client_test
 
 import (
@@ -5,6 +18,7 @@ import (
 	"errors"
 	"io"
 	"net"
+	"sync"
 	"testing"
 	"time"
 
@@ -85,10 +99,13 @@ func init() {
 }
 
 type recordPool struct {
+	mu        sync.Mutex
 	addresses []string
 }
 
 func (p *recordPool) Get(_ string, address string, _ connpool.GetOptions) (net.Conn, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
 	p.addresses = append(p.addresses, address)
 	return preWarmNopConn{}, nil
 }

--- a/client/pre_warm_test.go
+++ b/client/pre_warm_test.go
@@ -1,0 +1,112 @@
+package client_test
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"trpc.group/trpc-go/trpc-go/client"
+	"trpc.group/trpc-go/trpc-go/naming/registry"
+	"trpc.group/trpc-go/trpc-go/naming/selector"
+	"trpc.group/trpc-go/trpc-go/pool/connpool"
+	"trpc.group/trpc-go/trpc-go/transport"
+)
+
+func TestInitializableClientPreWarm(t *testing.T) {
+	cli, ok := client.New().(client.InitializableClient)
+	require.True(t, ok)
+
+	pool := &recordPool{}
+	require.NoError(t, cli.Init(context.Background(),
+		client.WithTarget("prewarm-selector://backend"),
+		client.WithPool(pool),
+		client.WithPreWarm(transport.PreWarmOptions{ConnsPerNode: 2}),
+	))
+	require.Equal(t, []string{"10.0.0.1:8000", "10.0.0.1:8000"}, pool.addresses)
+}
+
+func TestInitializableClientPreWarmDisabled(t *testing.T) {
+	cli, ok := client.New().(client.InitializableClient)
+	require.True(t, ok)
+
+	pool := &recordPool{}
+	require.NoError(t, cli.Init(context.Background(),
+		client.WithTarget("prewarm-selector://backend"),
+		client.WithPool(pool),
+		client.WithPreWarm(transport.PreWarmOptions{}),
+	))
+	require.Empty(t, pool.addresses)
+}
+
+func TestInitializableClientPreWarmInvalidConfig(t *testing.T) {
+	cli, ok := client.New().(client.InitializableClient)
+	require.True(t, ok)
+
+	err := cli.Init(context.Background(),
+		client.WithTarget("prewarm-selector://backend"),
+		client.WithDisableConnectionPool(),
+		client.WithPreWarm(transport.PreWarmOptions{ConnsPerNode: 1}),
+	)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "connection pool is disabled")
+}
+
+func TestInitializableClientPreWarmTimeout(t *testing.T) {
+	cli, ok := client.New().(client.InitializableClient)
+	require.True(t, ok)
+
+	err := cli.Init(context.Background(),
+		client.WithTarget("prewarm-selector://backend"),
+		client.WithPool(&blockingPool{}),
+		client.WithPreWarm(transport.PreWarmOptions{ConnsPerNode: 1, Timeout: time.Millisecond}),
+	)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), context.DeadlineExceeded.Error())
+}
+
+type preWarmSelector struct{}
+
+func (preWarmSelector) Select(serviceName string, _ ...selector.Option) (*registry.Node, error) {
+	if serviceName == "backend" {
+		return &registry.Node{Network: "tcp", Address: "10.0.0.1:8000"}, nil
+	}
+	return nil, errors.New("unknown service")
+}
+
+func (preWarmSelector) Report(*registry.Node, time.Duration, error) error { return nil }
+
+func init() {
+	selector.Register("prewarm-selector", preWarmSelector{})
+}
+
+type recordPool struct {
+	addresses []string
+}
+
+func (p *recordPool) Get(_ string, address string, _ connpool.GetOptions) (net.Conn, error) {
+	p.addresses = append(p.addresses, address)
+	return preWarmNopConn{}, nil
+}
+
+type blockingPool struct{}
+
+func (blockingPool) Get(_ string, _ string, opts connpool.GetOptions) (net.Conn, error) {
+	<-opts.Ctx.Done()
+	return nil, opts.Ctx.Err()
+}
+
+type preWarmNopConn struct{}
+
+func (preWarmNopConn) Read(_ []byte) (int, error)       { return 0, io.EOF }
+func (preWarmNopConn) Write(p []byte) (int, error)      { return len(p), nil }
+func (preWarmNopConn) Close() error                     { return nil }
+func (preWarmNopConn) LocalAddr() net.Addr              { return newUnresolvedAddr("tcp", "local") }
+func (preWarmNopConn) RemoteAddr() net.Addr             { return newUnresolvedAddr("tcp", "remote") }
+func (preWarmNopConn) SetDeadline(time.Time) error      { return nil }
+func (preWarmNopConn) SetReadDeadline(time.Time) error  { return nil }
+func (preWarmNopConn) SetWriteDeadline(time.Time) error { return nil }

--- a/internal/prewarm/pre_warm.go
+++ b/internal/prewarm/pre_warm.go
@@ -1,3 +1,16 @@
+//
+//
+// Tencent is pleased to support the open source community by making tRPC available.
+//
+// Copyright (C) 2023 Tencent.
+// All rights reserved.
+//
+// If you have downloaded a copy of the tRPC source code from Tencent,
+// please note that tRPC source code is licensed under the  Apache 2.0 License,
+// A copy of the Apache 2.0 License is included in this file.
+//
+//
+
 // Package prewarm implements client connection prewarming.
 package prewarm
 

--- a/internal/prewarm/pre_warm.go
+++ b/internal/prewarm/pre_warm.go
@@ -1,0 +1,233 @@
+// Package prewarm implements client connection prewarming.
+package prewarm
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"runtime"
+	"sync"
+	"sync/atomic"
+
+	"github.com/hashicorp/go-multierror"
+
+	"trpc.group/trpc-go/trpc-go/codec"
+	"trpc.group/trpc-go/trpc-go/naming/registry"
+	"trpc.group/trpc-go/trpc-go/pool/connpool"
+	"trpc.group/trpc-go/trpc-go/pool/multiplexed"
+	"trpc.group/trpc-go/trpc-go/transport"
+)
+
+var supportedNetworks = map[string]struct{}{
+	"tcp":  {},
+	"tcp4": {},
+	"tcp6": {},
+	"unix": {},
+}
+
+// Enabled checks if prewarming is enabled.
+func Enabled(_ context.Context, opts ...transport.RoundTripOption) bool {
+	roundTripOpts := &transport.RoundTripOptions{}
+	for _, o := range opts {
+		o(roundTripOpts)
+	}
+	return roundTripOpts.PreWarm != nil && roundTripOpts.PreWarm.ConnsPerNode > 0
+}
+
+// ValidateConfig validates the configuration for prewarming.
+func ValidateConfig(opts *transport.RoundTripOptions) error {
+	if opts == nil {
+		return errors.New("prewarm options empty")
+	}
+	if _, ok := supportedNetworks[opts.Network]; !ok {
+		return fmt.Errorf("network %s not supported", opts.Network)
+	}
+	if opts.DisableConnectionPool {
+		return errors.New("prewarm is not supported when connection pool is disabled")
+	}
+	if opts.PreWarm == nil || opts.PreWarm.ConnsPerNode <= 0 {
+		return errors.New("prewarm connections per node must be greater than zero")
+	}
+	if opts.EnableMultiplexed {
+		if opts.Multiplexed == nil {
+			return errors.New("prewarm multiplexed pool empty")
+		}
+		if opts.FramerBuilder == nil {
+			return errors.New("prewarm framer builder empty")
+		}
+		return nil
+	}
+	if opts.Pool == nil {
+		return errors.New("prewarm connection pool empty")
+	}
+	return nil
+}
+
+// PreWarm prewarms the multiplexed or connection pool.
+func PreWarm(ctx context.Context, nodeList []*registry.Node, opts *transport.RoundTripOptions) error {
+	if len(nodeList) == 0 {
+		return nil
+	}
+	if err := ValidateConfig(opts); err != nil {
+		return err
+	}
+	if opts.EnableMultiplexed {
+		return preWarm[muxConn](ctx, nodeList, opts, &muxPool{pool: opts.Multiplexed})
+	}
+	return preWarm[net.Conn](ctx, nodeList, opts, &connPool{pool: opts.Pool})
+}
+
+type prewarmConn interface {
+	Close() error
+}
+
+type prewarmPool[C prewarmConn] interface {
+	Get(ctx context.Context, network, address string, opts *transport.RoundTripOptions) (C, error)
+}
+
+func preWarm[C prewarmConn](
+	ctx context.Context,
+	nodeList []*registry.Node,
+	opts *transport.RoundTripOptions,
+	pool prewarmPool[C],
+) error {
+	parallelism := runtime.GOMAXPROCS(0)
+	if parallelism <= 0 {
+		parallelism = 1
+	}
+	sem := make(chan struct{}, parallelism)
+	errs := make(chan error, len(nodeList)*opts.PreWarm.ConnsPerNode)
+	var wg sync.WaitGroup
+
+	for _, node := range nodeList {
+		if node == nil || node.Address == "" {
+			continue
+		}
+		for i := 0; i < opts.PreWarm.ConnsPerNode; i++ {
+			wg.Add(1)
+			go func(node *registry.Node) {
+				defer wg.Done()
+				select {
+				case sem <- struct{}{}:
+					defer func() { <-sem }()
+				case <-ctx.Done():
+					errs <- fmt.Errorf("prewarm canceled before establish connection for %s: %w", node.Address, ctx.Err())
+					return
+				}
+				if err := establish(ctx, node, opts, pool); err != nil {
+					errs <- err
+				}
+			}(node)
+		}
+	}
+
+	wg.Wait()
+	close(errs)
+
+	var err error
+	for e := range errs {
+		err = multierror.Append(err, e)
+	}
+	return err
+}
+
+func establish[C prewarmConn](
+	ctx context.Context,
+	node *registry.Node,
+	opts *transport.RoundTripOptions,
+	pool prewarmPool[C],
+) error {
+	if err := ctx.Err(); err != nil {
+		return fmt.Errorf("prewarm canceled before establish connection for %s: %w", node.Address, err)
+	}
+
+	taskCtx, msg := codec.WithCloneContextAndMessage(ctx)
+	defer codec.PutBackMessage(msg)
+	if deadline, ok := ctx.Deadline(); ok {
+		var cancel context.CancelFunc
+		taskCtx, cancel = context.WithDeadline(taskCtx, deadline)
+		defer cancel()
+	}
+
+	network := opts.Network
+	if node.Network != "" {
+		network = node.Network
+	}
+	conn, err := pool.Get(taskCtx, network, node.Address, opts)
+	if err != nil {
+		return fmt.Errorf("establish connection for %s/%s: %w", network, node.Address, err)
+	}
+	if err := taskCtx.Err(); err != nil {
+		closeErr := conn.Close()
+		if closeErr != nil {
+			return multierror.Append(
+				fmt.Errorf("prewarm canceled after establish connection for %s/%s: %w", network, node.Address, err),
+				fmt.Errorf("close connection for %s/%s: %w", network, node.Address, closeErr),
+			)
+		}
+		return fmt.Errorf("prewarm canceled after establish connection for %s/%s: %w", network, node.Address, err)
+	}
+	if err := conn.Close(); err != nil {
+		return fmt.Errorf("close connection for %s/%s: %w", network, node.Address, err)
+	}
+	return nil
+}
+
+type connPool struct {
+	pool connpool.Pool
+}
+
+func (p *connPool) Get(
+	ctx context.Context,
+	network string,
+	address string,
+	opts *transport.RoundTripOptions,
+) (net.Conn, error) {
+	getOpts := connpool.NewGetOptions()
+	getOpts.WithContext(ctx)
+	getOpts.WithFramerBuilder(opts.FramerBuilder)
+	getOpts.WithDialTLS(opts.TLSCertFile, opts.TLSKeyFile, opts.CACertFile, opts.TLSServerName)
+	getOpts.WithCertProvider(opts.TLSCertProvider)
+	getOpts.WithLocalAddr(opts.LocalAddr)
+	getOpts.WithDialTimeout(opts.DialTimeout)
+	getOpts.WithProtocol(opts.Protocol)
+	return p.pool.Get(network, address, getOpts)
+}
+
+type muxConn struct {
+	multiplexed.MuxConn
+}
+
+func (c muxConn) Close() error {
+	c.MuxConn.Close()
+	return nil
+}
+
+type muxPool struct {
+	pool multiplexed.Pool
+	vid  uint32
+}
+
+func (p *muxPool) Get(
+	ctx context.Context,
+	network string,
+	address string,
+	opts *transport.RoundTripOptions,
+) (muxConn, error) {
+	getOpts := multiplexed.NewGetOptions()
+	getOpts.WithVID(atomic.AddUint32(&p.vid, 1))
+	fp, ok := opts.FramerBuilder.(multiplexed.FrameParser)
+	if !ok {
+		return muxConn{}, errors.New("frame builder does not implement multiplexed.FrameParser")
+	}
+	getOpts.WithFrameParser(fp)
+	getOpts.WithDialTLS(opts.TLSCertFile, opts.TLSKeyFile, opts.CACertFile, opts.TLSServerName)
+	getOpts.WithCertProvider(opts.TLSCertProvider)
+	getOpts.WithLocalAddr(opts.LocalAddr)
+	conn, err := p.pool.GetMuxConn(ctx, network, address, getOpts)
+	if err != nil {
+		return muxConn{}, err
+	}
+	return muxConn{MuxConn: conn}, nil
+}

--- a/internal/prewarm/pre_warm_test.go
+++ b/internal/prewarm/pre_warm_test.go
@@ -1,0 +1,157 @@
+package prewarm_test
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	trpc "trpc.group/trpc-go/trpc-go"
+	"trpc.group/trpc-go/trpc-go/codec"
+	"trpc.group/trpc-go/trpc-go/internal/prewarm"
+	"trpc.group/trpc-go/trpc-go/naming/registry"
+	"trpc.group/trpc-go/trpc-go/pool/connpool"
+	"trpc.group/trpc-go/trpc-go/pool/multiplexed"
+	"trpc.group/trpc-go/trpc-go/transport"
+)
+
+func TestEnabled(t *testing.T) {
+	require.True(t, prewarm.Enabled(context.Background(),
+		transport.WithPreWarm(transport.PreWarmOptions{ConnsPerNode: 1})))
+	require.False(t, prewarm.Enabled(context.Background(),
+		transport.WithPreWarm(transport.PreWarmOptions{})))
+	require.False(t, prewarm.Enabled(context.Background()))
+}
+
+func TestValidateConfig(t *testing.T) {
+	tests := []struct {
+		name string
+		opts *transport.RoundTripOptions
+		ok   bool
+	}{
+		{name: "tcp", opts: &transport.RoundTripOptions{
+			Network: "tcp", Pool: connpool.DefaultConnectionPool,
+			PreWarm: &transport.PreWarmOptions{ConnsPerNode: 1},
+		}, ok: true},
+		{name: "tcp4", opts: &transport.RoundTripOptions{
+			Network: "tcp4", Pool: connpool.DefaultConnectionPool,
+			PreWarm: &transport.PreWarmOptions{ConnsPerNode: 1},
+		}, ok: true},
+		{name: "tcp6", opts: &transport.RoundTripOptions{
+			Network: "tcp6", Pool: connpool.DefaultConnectionPool,
+			PreWarm: &transport.PreWarmOptions{ConnsPerNode: 1},
+		}, ok: true},
+		{name: "unix", opts: &transport.RoundTripOptions{
+			Network: "unix", Pool: connpool.DefaultConnectionPool,
+			PreWarm: &transport.PreWarmOptions{ConnsPerNode: 1},
+		}, ok: true},
+		{name: "udp", opts: &transport.RoundTripOptions{
+			Network: "udp", Pool: connpool.DefaultConnectionPool,
+			PreWarm: &transport.PreWarmOptions{ConnsPerNode: 1},
+		}},
+		{name: "disabled pool", opts: &transport.RoundTripOptions{
+			Network: "tcp", DisableConnectionPool: true,
+			PreWarm: &transport.PreWarmOptions{ConnsPerNode: 1},
+		}},
+		{name: "zero connections", opts: &transport.RoundTripOptions{
+			Network: "tcp", Pool: connpool.DefaultConnectionPool,
+			PreWarm: &transport.PreWarmOptions{},
+		}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := prewarm.ValidateConfig(tt.opts)
+			require.Equal(t, tt.ok, err == nil)
+		})
+	}
+}
+
+func TestPreWarmConnPool(t *testing.T) {
+	var gets atomic.Int32
+	pool := &countingPool{gets: &gets}
+	nodes := []*registry.Node{{Network: "tcp", Address: "127.0.0.1:1"}, {Address: "127.0.0.1:2"}}
+	opts := &transport.RoundTripOptions{
+		Network: "tcp",
+		Pool:    pool,
+		PreWarm: &transport.PreWarmOptions{ConnsPerNode: 2},
+	}
+	require.NoError(t, prewarm.PreWarm(context.Background(), nodes, opts))
+	require.Equal(t, int32(4), gets.Load())
+}
+
+func TestPreWarmConnPoolError(t *testing.T) {
+	opts := &transport.RoundTripOptions{
+		Network: "tcp",
+		Pool:    errPool{},
+		PreWarm: &transport.PreWarmOptions{ConnsPerNode: 1},
+	}
+	err := prewarm.PreWarm(context.Background(), []*registry.Node{{Address: "127.0.0.1:1"}}, opts)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "establish connection")
+}
+
+func TestPreWarmMultiplexed(t *testing.T) {
+	l, err := net.Listen("tcp", "127.0.0.1:")
+	require.NoError(t, err)
+	defer l.Close()
+
+	opts := &transport.RoundTripOptions{
+		Network:           "tcp",
+		Multiplexed:       multiplexed.New(),
+		EnableMultiplexed: true,
+		Msg:               codec.Message(trpc.BackgroundContext()),
+		FramerBuilder:     trpc.DefaultFramerBuilder,
+		PreWarm:           &transport.PreWarmOptions{ConnsPerNode: 1},
+	}
+	nodes := []*registry.Node{{Address: l.Addr().String()}}
+	require.NoError(t, prewarm.PreWarm(context.Background(), nodes, opts))
+}
+
+func TestPreWarmContextCanceled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	opts := &transport.RoundTripOptions{
+		Network: "tcp",
+		Pool:    connpool.DefaultConnectionPool,
+		PreWarm: &transport.PreWarmOptions{ConnsPerNode: 1},
+	}
+	err := prewarm.PreWarm(ctx, []*registry.Node{{Address: "127.0.0.1:1"}}, opts)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), context.Canceled.Error())
+}
+
+type countingPool struct {
+	gets *atomic.Int32
+}
+
+func (p *countingPool) Get(_ string, _ string, _ connpool.GetOptions) (net.Conn, error) {
+	p.gets.Add(1)
+	return nopConn{}, nil
+}
+
+type errPool struct{}
+
+func (errPool) Get(_ string, _ string, _ connpool.GetOptions) (net.Conn, error) {
+	return nil, errors.New("get connection failed")
+}
+
+type nopConn struct{}
+
+func (nopConn) Read(_ []byte) (int, error)       { return 0, io.EOF }
+func (nopConn) Write(p []byte) (int, error)      { return len(p), nil }
+func (nopConn) Close() error                     { return nil }
+func (nopConn) LocalAddr() net.Addr              { return dummyAddr("local") }
+func (nopConn) RemoteAddr() net.Addr             { return dummyAddr("remote") }
+func (nopConn) SetDeadline(time.Time) error      { return nil }
+func (nopConn) SetReadDeadline(time.Time) error  { return nil }
+func (nopConn) SetWriteDeadline(time.Time) error { return nil }
+
+type dummyAddr string
+
+func (a dummyAddr) Network() string { return string(a) }
+func (a dummyAddr) String() string  { return string(a) }

--- a/internal/prewarm/pre_warm_test.go
+++ b/internal/prewarm/pre_warm_test.go
@@ -1,3 +1,16 @@
+//
+//
+// Tencent is pleased to support the open source community by making tRPC available.
+//
+// Copyright (C) 2023 Tencent.
+// All rights reserved.
+//
+// If you have downloaded a copy of the tRPC source code from Tencent,
+// please note that tRPC source code is licensed under the  Apache 2.0 License,
+// A copy of the Apache 2.0 License is included in this file.
+//
+//
+
 package prewarm_test
 
 import (

--- a/transport/client_roundtrip_options.go
+++ b/transport/client_roundtrip_options.go
@@ -37,12 +37,22 @@ type RoundTripOptions struct {
 	Multiplexed           multiplexed.Pool
 	Msg                   codec.Msg
 	Protocol              string // protocol type
+	PreWarm               *PreWarmOptions
 
 	CACertFile      string // CA certificate file
 	TLSCertFile     string // client certificate file
 	TLSKeyFile      string // client key file
 	TLSCertProvider string // provider used to load TLS certificate files
 	TLSServerName   string // the name when client verifies the server, default as HTTP hostname
+}
+
+// PreWarmOptions configures client connection prewarming.
+type PreWarmOptions struct {
+	// ConnsPerNode is the number of connections to prewarm for each selected node.
+	// Zero disables prewarming.
+	ConnsPerNode int
+	// Timeout is the optional total timeout for prewarming.
+	Timeout time.Duration
 }
 
 // ConnectionMode is the connection mode, either Connected or NotConnected.
@@ -181,5 +191,13 @@ func WithDialTimeout(dur time.Duration) RoundTripOption {
 func WithProtocol(s string) RoundTripOption {
 	return func(o *RoundTripOptions) {
 		o.Protocol = s
+	}
+}
+
+// WithPreWarm returns a RoundTripOption which sets prewarm options.
+// This option is intended for client initialization.
+func WithPreWarm(p PreWarmOptions) RoundTripOption {
+	return func(o *RoundTripOptions) {
+		o.PreWarm = &p
 	}
 }


### PR DESCRIPTION
## Summary
- add explicit client initialization support through `client.InitializableClient`
- add `client.WithPreWarm` / `transport.WithPreWarm` and YAML `pre_warm` config
- prewarm connpool and multiplexed client connections with validation and targeted tests

## Compatibility
- does not add methods to the existing `client.Client` interface
- prewarming is disabled unless `ConnsPerNode` is greater than zero
- custom selectors fall back to one selected node instead of requiring a node-list API

## Tests
- `go test ./internal/prewarm ./client ./transport -count=1`
- `go test ./... -count=1`
- `go test -v -coverprofile=coverage.out ./...`
