### PR TITLE
server: support precool checks

### DIFF
--- a/admin/admin.go
+++ b/admin/admin.go
@@ -35,6 +35,7 @@ import (
 	"trpc.group/trpc-go/trpc-go/errs"
 	"trpc.group/trpc-go/trpc-go/healthcheck"
 	"trpc.group/trpc-go/trpc-go/log"
+	"trpc.group/trpc-go/trpc-go/precool"
 	"trpc.group/trpc-go/trpc-go/rpcz"
 	"trpc.group/trpc-go/trpc-go/transport"
 )
@@ -72,6 +73,7 @@ const (
 	patternLoglevel      = "/cmds/loglevel"
 	patternConfig        = "/cmds/config"
 	patternHealthCheck   = "/is_healthy/"
+	patternPrecool       = "/cmds/is_precool/"
 	patternRPCZSpansList = "/cmds/rpcz/spans"
 	patternRPCZSpanGet   = "/cmds/rpcz/spans/"
 )
@@ -100,6 +102,7 @@ type Server struct {
 
 	router      *router
 	healthCheck *healthcheck.HealthCheck
+	precool     precool.Checker
 
 	closeOnce sync.Once
 	closeErr  error
@@ -115,6 +118,7 @@ func NewServer(opts ...Option) *Server {
 	s := &Server{
 		config:      cfg,
 		healthCheck: healthcheck.New(healthcheck.WithStatusWatchers(healthcheck.GetWatchers())),
+		precool:     cfg.precoolCheck,
 	}
 	if !cfg.skipServe {
 		s.router = s.configRouter(newRouter())
@@ -132,6 +136,11 @@ func (s *Server) configRouter(r *router) *router {
 			http.HandlerFunc(s.handleHealthCheck),
 		).ServeHTTP,
 	) // Health check.
+	r.add(patternPrecool,
+		http.StripPrefix(patternPrecool,
+			http.HandlerFunc(s.handlePrecool),
+		).ServeHTTP,
+	) // Precool check.
 
 	r.add(patternRPCZSpansList, s.handleRPCZSpansList)
 	r.add(patternRPCZSpanGet, s.handleRPCZSpanGet)
@@ -397,6 +406,32 @@ func (s *Server) handleHealthCheck(w http.ResponseWriter, r *http.Request) {
 	default:
 		w.WriteHeader(http.StatusNotFound)
 	}
+}
+
+func (s *Server) handlePrecool(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		w.Header().Set("Allow", http.MethodGet)
+		http.Error(w, http.StatusText(http.StatusMethodNotAllowed), http.StatusMethodNotAllowed)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	if s.precool == nil {
+		ret := newDefaultRes()
+		ret[retErrCode] = errCodeServer
+		ret["is_precool"] = ""
+		ret[retMessage] = "precool checker is not initialized"
+		_ = json.NewEncoder(w).Encode(ret)
+		return
+	}
+
+	serviceName := strings.TrimLeft(r.URL.Path, "/")
+	status := s.precool.CheckServer()
+	if serviceName != "" {
+		status = s.precool.CheckService(serviceName)
+	}
+	ret := newDefaultRes()
+	ret["is_precool"] = status.String()
+	_ = json.NewEncoder(w).Encode(ret)
 }
 
 // handleRPCZSpansList returns #xxx span from r by url "http://ip:port/cmds/rpcz/spans?num=xxx".

--- a/admin/admin_test.go
+++ b/admin/admin_test.go
@@ -36,6 +36,7 @@ import (
 	"trpc.group/trpc-go/trpc-go/config"
 	"trpc.group/trpc-go/trpc-go/healthcheck"
 	"trpc.group/trpc-go/trpc-go/log"
+	"trpc.group/trpc-go/trpc-go/precool"
 	"trpc.group/trpc-go/trpc-go/rpcz"
 	"trpc.group/trpc-go/trpc-go/transport"
 )
@@ -462,6 +463,76 @@ func TestCmdsHealthCheck(t *testing.T) {
 	rsp, err = http.Get(fmt.Sprintf("http://%s/is_healthy/service", s.server.Addr))
 	require.Nil(t, err)
 	require.Equal(t, http.StatusNotFound, rsp.StatusCode)
+}
+
+func TestCmdsPrecool(t *testing.T) {
+	checker := &mockPrecoolChecker{
+		serverStatus: precool.Success,
+		serviceStatus: map[string]precool.Status{
+			"svc": precool.Ongoing,
+		},
+	}
+	s := NewServer(
+		WithVersion(testVersion),
+		WithAddr(testAddress),
+		WithConfigPath(testConfigPath),
+		WithPrecool(checker),
+	)
+	mustStartAdminServer(t, s)
+	t.Cleanup(func() {
+		if err := s.Close(nil); err != nil {
+			t.Log(err)
+		}
+	})
+
+	baseURL := fmt.Sprintf("http://%s", s.server.Addr)
+	rsp, err := httpRequest(http.MethodGet, baseURL+"/cmds/is_precool/", "")
+	require.NoError(t, err)
+	require.Contains(t, string(rsp), `"is_precool":"proc_success"`)
+
+	rsp, err = httpRequest(http.MethodGet, baseURL+"/cmds/is_precool/svc", "")
+	require.NoError(t, err)
+	require.Contains(t, string(rsp), `"is_precool":"proc_ongoing"`)
+
+	rsp, err = httpRequest(http.MethodPost, baseURL+"/cmds/is_precool/", "")
+	require.NoError(t, err)
+	require.Contains(t, string(rsp), "Method Not Allowed")
+}
+
+func TestCmdsPrecoolWithoutChecker(t *testing.T) {
+	s := newDefaultAdminServer()
+	mustStartAdminServer(t, s)
+	t.Cleanup(func() {
+		if err := s.Close(nil); err != nil {
+			t.Log(err)
+		}
+	})
+
+	rsp, err := httpRequest(http.MethodGet, fmt.Sprintf("http://%s/cmds/is_precool/", s.server.Addr), "")
+	require.NoError(t, err)
+	require.Contains(t, string(rsp), "precool checker is not initialized")
+}
+
+type mockPrecoolChecker struct {
+	serverStatus  precool.Status
+	serviceStatus map[string]precool.Status
+}
+
+func (m *mockPrecoolChecker) Register(string, precool.Func) error {
+	return nil
+}
+
+func (m *mockPrecoolChecker) Unregister(string) {}
+
+func (m *mockPrecoolChecker) CheckService(name string) precool.Status {
+	if status, ok := m.serviceStatus[name]; ok {
+		return status
+	}
+	return precool.Unknown
+}
+
+func (m *mockPrecoolChecker) CheckServer() precool.Status {
+	return m.serverStatus
 }
 
 func TestCmds(t *testing.T) {

--- a/admin/config.go
+++ b/admin/config.go
@@ -15,6 +15,8 @@ package admin
 
 import (
 	"time"
+
+	"trpc.group/trpc-go/trpc-go/precool"
 )
 
 const (
@@ -44,4 +46,5 @@ type configuration struct {
 	version      string
 	configPath   string
 	skipServe    bool
+	precoolCheck precool.Checker
 }

--- a/admin/options.go
+++ b/admin/options.go
@@ -15,6 +15,8 @@ package admin
 
 import (
 	"time"
+
+	"trpc.group/trpc-go/trpc-go/precool"
 )
 
 // Option Service configuration options.
@@ -75,5 +77,12 @@ func WithConfigPath(configPath string) Option {
 func WithSkipServe(isSkip bool) Option {
 	return func(config *configuration) {
 		config.skipServe = isSkip
+	}
+}
+
+// WithPrecool sets the precool checker used by the admin precool endpoint.
+func WithPrecool(pc precool.Checker) Option {
+	return func(config *configuration) {
+		config.precoolCheck = pc
 	}
 }

--- a/internal/precool/precool.go
+++ b/internal/precool/precool.go
@@ -1,0 +1,105 @@
+// Package precool implements service-level precool checks.
+package precool
+
+import (
+	"fmt"
+	"sync"
+
+	"trpc.group/trpc-go/trpc-go/precool"
+)
+
+// Option configures a Check.
+type Option func(*Check)
+
+// WithUnregisteredServiceStatus sets the status returned for unregistered services.
+func WithUnregisteredServiceStatus(status precool.Status) Option {
+	return func(pc *Check) {
+		pc.unregisteredServiceStatus = status
+	}
+}
+
+// Check provides service-level precool detection.
+type Check struct {
+	unregisteredServiceStatus precool.Status
+
+	mu    sync.RWMutex
+	funcs map[string]precool.Func
+}
+
+// New creates a new Check instance.
+func New(opts ...Option) *Check {
+	pc := &Check{
+		unregisteredServiceStatus: precool.Unknown,
+		funcs:                     make(map[string]precool.Func),
+	}
+	for _, opt := range opts {
+		opt(pc)
+	}
+	return pc
+}
+
+// Register registers a service with a custom precool strategy.
+func (pc *Check) Register(name string, fn precool.Func) error {
+	pc.mu.Lock()
+	defer pc.mu.Unlock()
+	if _, ok := pc.funcs[name]; ok {
+		return fmt.Errorf("service %s has been registered", name)
+	}
+	pc.funcs[name] = fn
+	return nil
+}
+
+// Unregister unregisters a service from precool check.
+func (pc *Check) Unregister(name string) {
+	pc.mu.Lock()
+	defer pc.mu.Unlock()
+	delete(pc.funcs, name)
+}
+
+// CheckService returns the precool status of a specific service.
+func (pc *Check) CheckService(name string) precool.Status {
+	pc.mu.RLock()
+	defer pc.mu.RUnlock()
+	fn, ok := pc.funcs[name]
+	if !ok {
+		return pc.unregisteredServiceStatus
+	}
+	return fn()
+}
+
+// CheckServer returns the aggregate precool status of the entire server.
+func (pc *Check) CheckServer() precool.Status {
+	pc.mu.RLock()
+	defer pc.mu.RUnlock()
+	if len(pc.funcs) == 0 {
+		return precool.Success
+	}
+	var (
+		hasFailure bool
+		hasOngoing bool
+		allSuccess = true
+	)
+	for _, fn := range pc.funcs {
+		switch fn() {
+		case precool.Failure:
+			hasFailure = true
+			allSuccess = false
+		case precool.Ongoing:
+			hasOngoing = true
+			allSuccess = false
+		case precool.Success:
+		default:
+			allSuccess = false
+		}
+	}
+	if hasFailure {
+		return precool.Unknown
+	}
+	if hasOngoing {
+		return precool.Ongoing
+	}
+	if allSuccess {
+		return precool.Success
+	}
+	return precool.Failure
+}

--- a/internal/precool/precool.go
+++ b/internal/precool/precool.go
@@ -1,3 +1,16 @@
+//
+//
+// Tencent is pleased to support the open source community by making tRPC available.
+//
+// Copyright (C) 2023 Tencent.
+// All rights reserved.
+//
+// If you have downloaded a copy of the tRPC source code from Tencent,
+// please note that tRPC source code is licensed under the  Apache 2.0 License,
+// A copy of the Apache 2.0 License is included in this file.
+//
+//
+
 // Package precool implements service-level precool checks.
 package precool
 

--- a/internal/precool/precool_test.go
+++ b/internal/precool/precool_test.go
@@ -1,3 +1,16 @@
+//
+//
+// Tencent is pleased to support the open source community by making tRPC available.
+//
+// Copyright (C) 2023 Tencent.
+// All rights reserved.
+//
+// If you have downloaded a copy of the tRPC source code from Tencent,
+// please note that tRPC source code is licensed under the  Apache 2.0 License,
+// A copy of the Apache 2.0 License is included in this file.
+//
+//
+
 package precool
 
 import (

--- a/internal/precool/precool_test.go
+++ b/internal/precool/precool_test.go
@@ -1,0 +1,80 @@
+package precool
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	coreprecool "trpc.group/trpc-go/trpc-go/precool"
+)
+
+func TestNewAndWithUnregisteredServiceStatus(t *testing.T) {
+	pc := New()
+	require.Equal(t, coreprecool.Unknown, pc.unregisteredServiceStatus)
+
+	pc = New(WithUnregisteredServiceStatus(coreprecool.Failure))
+	require.Equal(t, coreprecool.Failure, pc.unregisteredServiceStatus)
+}
+
+func TestRegisterAndUnregister(t *testing.T) {
+	pc := New()
+	fn := func() coreprecool.Status { return coreprecool.Success }
+
+	require.NoError(t, pc.Register("svc", fn))
+	require.Error(t, pc.Register("svc", fn))
+
+	pc.Unregister("svc")
+	require.NoError(t, pc.Register("svc", fn))
+}
+
+func TestCheckService(t *testing.T) {
+	pc := New(WithUnregisteredServiceStatus(coreprecool.Failure))
+	require.Equal(t, coreprecool.Failure, pc.CheckService("notfound"))
+
+	require.NoError(t, pc.Register("svc", func() coreprecool.Status { return coreprecool.Success }))
+	require.Equal(t, coreprecool.Success, pc.CheckService("svc"))
+}
+
+func TestCheckServer(t *testing.T) {
+	tests := []struct {
+		name     string
+		statuses map[string]coreprecool.Status
+		want     coreprecool.Status
+	}{
+		{
+			name:     "all success",
+			statuses: map[string]coreprecool.Status{"a": coreprecool.Success, "b": coreprecool.Success},
+			want:     coreprecool.Success,
+		},
+		{
+			name:     "has failure",
+			statuses: map[string]coreprecool.Status{"a": coreprecool.Success, "b": coreprecool.Failure},
+			want:     coreprecool.Unknown,
+		},
+		{
+			name:     "has ongoing",
+			statuses: map[string]coreprecool.Status{"a": coreprecool.Success, "b": coreprecool.Ongoing},
+			want:     coreprecool.Ongoing,
+		},
+		{
+			name:     "mixed unknown",
+			statuses: map[string]coreprecool.Status{"a": coreprecool.Success, "b": coreprecool.Unknown},
+			want:     coreprecool.Failure,
+		},
+		{
+			name:     "empty",
+			statuses: map[string]coreprecool.Status{},
+			want:     coreprecool.Success,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pc := New()
+			for name, status := range tt.statuses {
+				st := status
+				require.NoError(t, pc.Register(name, func() coreprecool.Status { return st }))
+			}
+			require.Equal(t, tt.want, pc.CheckServer())
+		})
+	}
+}

--- a/precool/precool.go
+++ b/precool/precool.go
@@ -1,0 +1,45 @@
+// Package precool provides service-level precool status primitives.
+package precool
+
+// Status represents the precool status of a service.
+type Status int
+
+const (
+	// Unknown indicates the service is not registered or its precool status is unknown.
+	Unknown Status = iota
+	// Success indicates the service precool process has completed successfully.
+	Success
+	// Failure indicates the service precool process has failed.
+	Failure
+	// Ongoing indicates the service precool process is still running.
+	Ongoing
+)
+
+// String returns the string representation of the status.
+func (s Status) String() string {
+	switch s {
+	case Success:
+		return "proc_success"
+	case Failure:
+		return "proc_failure"
+	case Ongoing:
+		return "proc_ongoing"
+	default:
+		return "unknown"
+	}
+}
+
+// Func is the function type for custom precool strategies.
+type Func func() Status
+
+// Checker wraps the basic precool check methods.
+type Checker interface {
+	// Register registers a service with a custom precool strategy.
+	Register(name string, fn Func) error
+	// Unregister unregisters a service from precool check.
+	Unregister(name string)
+	// CheckService returns the precool status of a specific service.
+	CheckService(name string) Status
+	// CheckServer returns the precool status of the entire server.
+	CheckServer() Status
+}

--- a/precool/precool.go
+++ b/precool/precool.go
@@ -1,3 +1,16 @@
+//
+//
+// Tencent is pleased to support the open source community by making tRPC available.
+//
+// Copyright (C) 2023 Tencent.
+// All rights reserved.
+//
+// If you have downloaded a copy of the tRPC source code from Tencent,
+// please note that tRPC source code is licensed under the  Apache 2.0 License,
+// A copy of the Apache 2.0 License is included in this file.
+//
+//
+
 // Package precool provides service-level precool status primitives.
 package precool
 

--- a/precool/precool_test.go
+++ b/precool/precool_test.go
@@ -1,3 +1,16 @@
+//
+//
+// Tencent is pleased to support the open source community by making tRPC available.
+//
+// Copyright (C) 2023 Tencent.
+// All rights reserved.
+//
+// If you have downloaded a copy of the tRPC source code from Tencent,
+// please note that tRPC source code is licensed under the  Apache 2.0 License,
+// A copy of the Apache 2.0 License is included in this file.
+//
+//
+
 package precool_test
 
 import (

--- a/precool/precool_test.go
+++ b/precool/precool_test.go
@@ -1,0 +1,25 @@
+package precool_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"trpc.group/trpc-go/trpc-go/precool"
+)
+
+func TestStatusString(t *testing.T) {
+	tests := []struct {
+		status precool.Status
+		want   string
+	}{
+		{status: precool.Unknown, want: "unknown"},
+		{status: precool.Success, want: "proc_success"},
+		{status: precool.Failure, want: "proc_failure"},
+		{status: precool.Ongoing, want: "proc_ongoing"},
+		{status: precool.Status(99), want: "unknown"},
+	}
+	for _, tt := range tests {
+		require.Equal(t, tt.want, tt.status.String())
+	}
+}

--- a/server/options.go
+++ b/server/options.go
@@ -21,6 +21,7 @@ import (
 	"trpc.group/trpc-go/trpc-go/codec"
 	"trpc.group/trpc-go/trpc-go/filter"
 	"trpc.group/trpc-go/trpc-go/naming/registry"
+	"trpc.group/trpc-go/trpc-go/precool"
 	"trpc.group/trpc-go/trpc-go/restful"
 	"trpc.group/trpc-go/trpc-go/transport"
 )
@@ -28,6 +29,8 @@ import (
 // Options are server side options.
 type Options struct {
 	container string // container name
+	// precoolChecker provides service-level precool detection for server-level APIs.
+	precoolChecker precool.Checker
 
 	Namespace   string // namespace like "Production", "Development" etc.
 	EnvName     string // environment name
@@ -325,6 +328,13 @@ func WithCloseWaitTime(t time.Duration) Option {
 func WithMaxCloseWaitTime(t time.Duration) Option {
 	return func(o *Options) {
 		o.MaxCloseWaitTime = t
+	}
+}
+
+// WithPrecool returns an Option that sets precool.Checker.
+func WithPrecool(checker precool.Checker) Option {
+	return func(o *Options) {
+		o.precoolChecker = checker
 	}
 }
 

--- a/server/server.go
+++ b/server/server.go
@@ -21,7 +21,21 @@ import (
 	"os"
 	"sync"
 	"time"
+
+	"trpc.group/trpc-go/trpc-go/precool"
 )
+
+// NewServer creates a new Server.
+func NewServer(opts ...Option) *Server {
+	var o Options
+	for _, opt := range opts {
+		opt(&o)
+	}
+	return &Server{
+		MaxCloseWaitTime: o.MaxCloseWaitTime,
+		precoolChecker:   o.precoolChecker,
+	}
+}
 
 // Server is a tRPC server.
 // One process, one server. A server may offer one or more services.
@@ -29,6 +43,8 @@ type Server struct {
 	MaxCloseWaitTime time.Duration // max waiting time when closing server
 
 	services map[string]Service // k=serviceName,v=Service
+	// precoolChecker provides service-level precool detection.
+	precoolChecker precool.Checker
 
 	mux sync.Mutex // guards onShutdownHooks and afterShutdownHooks
 	// onShutdownHooks are hook functions that would be executed when server is
@@ -169,4 +185,15 @@ func (s *Server) RegisterAfterShutdown(fn func()) {
 	s.mux.Lock()
 	s.afterShutdownHooks = append(s.afterShutdownHooks, fn)
 	s.mux.Unlock()
+}
+
+// RegisterServicePrecool registers a precool strategy for a specific service.
+func (s *Server) RegisterServicePrecool(serviceName string, fn precool.Func) error {
+	if fn == nil {
+		return errors.New("precool function cannot be nil")
+	}
+	if s.precoolChecker == nil {
+		return errors.New("precool checker is nil")
+	}
+	return s.precoolChecker.Register(serviceName, fn)
 }

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -25,6 +25,7 @@ import (
 	"trpc.group/trpc-go/trpc-go/codec"
 	"trpc.group/trpc-go/trpc-go/errs"
 	"trpc.group/trpc-go/trpc-go/naming/registry"
+	"trpc.group/trpc-go/trpc-go/precool"
 	"trpc.group/trpc-go/trpc-go/restful"
 	"trpc.group/trpc-go/trpc-go/server"
 	"trpc.group/trpc-go/trpc-go/transport"
@@ -291,6 +292,37 @@ func TestServerRegisterAfterShutdown(t *testing.T) {
 	require.Equal(t, "service", <-ch)
 	require.Equal(t, "after1", <-ch)
 	require.Equal(t, "after2", <-ch)
+}
+
+func TestRegisterServicePrecool(t *testing.T) {
+	checker := &serverPrecoolChecker{registered: make(map[string]precool.Func)}
+	s := server.NewServer(server.WithPrecool(checker))
+	require.NoError(t, s.RegisterServicePrecool("svc", func() precool.Status { return precool.Success }))
+	require.Contains(t, checker.registered, "svc")
+
+	require.Error(t, s.RegisterServicePrecool("svc2", nil))
+	require.Error(t, server.NewServer().RegisterServicePrecool("svc", func() precool.Status {
+		return precool.Success
+	}))
+}
+
+type serverPrecoolChecker struct {
+	registered map[string]precool.Func
+}
+
+func (m *serverPrecoolChecker) Register(name string, fn precool.Func) error {
+	m.registered[name] = fn
+	return nil
+}
+
+func (m *serverPrecoolChecker) Unregister(string) {}
+
+func (m *serverPrecoolChecker) CheckService(string) precool.Status {
+	return precool.Unknown
+}
+
+func (m *serverPrecoolChecker) CheckServer() precool.Status {
+	return precool.Unknown
 }
 
 type closeOrderService struct {

--- a/trpc.go
+++ b/trpc.go
@@ -21,8 +21,10 @@ import (
 
 	"trpc.group/trpc-go/trpc-go/admin"
 	"trpc.group/trpc-go/trpc-go/filter"
+	iprecool "trpc.group/trpc-go/trpc-go/internal/precool"
 	"trpc.group/trpc-go/trpc-go/log"
 	"trpc.group/trpc-go/trpc-go/naming/registry"
+	"trpc.group/trpc-go/trpc-go/precool"
 	"trpc.group/trpc-go/trpc-go/rpcz"
 	"trpc.group/trpc-go/trpc-go/server"
 	"trpc.group/trpc-go/trpc-go/transport"
@@ -74,12 +76,14 @@ func NewServerWithConfig(cfg *Config, opt ...server.Option) *server.Server {
 	// set to global Config
 	SetGlobalConfig(cfg)
 
-	s := &server.Server{
-		MaxCloseWaitTime: getMillisecond(cfg.Server.MaxCloseWaitTime),
-	}
+	pc := iprecool.New()
+	s := server.NewServer(
+		server.WithMaxCloseWaitTime(getMillisecond(cfg.Server.MaxCloseWaitTime)),
+		server.WithPrecool(pc),
+	)
 
 	// setup admin service
-	setupAdmin(s, cfg)
+	setupAdmin(s, cfg, pc)
 
 	// init service one by one
 	for _, c := range cfg.Server.Service {
@@ -97,7 +101,7 @@ func GetAdminService(s *server.Server) (*admin.Server, error) {
 	return adminServer, nil
 }
 
-func setupAdmin(s *server.Server, cfg *Config) {
+func setupAdmin(s *server.Server, cfg *Config, pc precool.Checker) {
 	// admin configured, then admin service will be started
 	opts := []admin.Option{
 		admin.WithSkipServe(cfg.Server.Admin.Port == 0),
@@ -106,6 +110,7 @@ func setupAdmin(s *server.Server, cfg *Config) {
 		admin.WithConfigPath(ServerConfigPath),
 		admin.WithReadTimeout(getMillisecond(cfg.Server.Admin.ReadTimeout)),
 		admin.WithWriteTimeout(getMillisecond(cfg.Server.Admin.WriteTimeout)),
+		admin.WithPrecool(pc),
 	}
 	if cfg.Server.Admin.Port > 0 {
 		opts = append(opts, admin.WithAddr(fmt.Sprintf("%s:%d", cfg.Server.Admin.IP, cfg.Server.Admin.Port)))


### PR DESCRIPTION
## Summary
- add public precool status primitives and an internal checker
- expose server-side service precool registration without changing existing interfaces
- add an admin /cmds/is_precool/ endpoint wired through trpc server setup

## Compatibility
- existing server and admin APIs remain unchanged
- precool is opt-in for services; unregistered services keep the existing runtime behavior
- no internal-only dependencies or private endpoints are introduced

## Tests
- go test ./precool ./internal/precool ./admin ./server -count=1
- go test ./... -count=1
- go test -cover ./precool ./internal/precool ./admin ./server -count=1