### PR TITLE
http: preserve cookie jar for TLS clients

### DIFF
--- a/http/transport.go
+++ b/http/transport.go
@@ -655,6 +655,7 @@ func (ct *ClientTransport) getStdHTTPClient(caFile, certFile,
 	}
 	client := &stdhttp.Client{
 		CheckRedirect: ct.Client.CheckRedirect,
+		Jar:           ct.Client.Jar,
 		Timeout:       ct.Client.Timeout,
 	}
 	if ct.http2Only {

--- a/http/transport_test.go
+++ b/http/transport_test.go
@@ -39,6 +39,7 @@ import (
 	"mime/multipart"
 	"net"
 	"net/http"
+	"net/http/cookiejar"
 	"net/http/httptest"
 	"net/url"
 	"os"
@@ -1046,6 +1047,41 @@ func TestHTTPSSkipClientVerify(t *testing.T) {
 			),
 		))
 	require.Equal(t, []byte(t.Name()), rsp.Data)
+}
+
+func TestTLSClientInheritsCookieJar(t *testing.T) {
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.SetCookie(w, &http.Cookie{Name: "sid", Value: "cookie-value"})
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	u, err := url.Parse(ts.URL)
+	require.NoError(t, err)
+	jar, err := cookiejar.New(nil)
+	require.NoError(t, err)
+
+	ct := thttp.NewClientTransport(false)
+	ct.(*thttp.ClientTransport).Jar = jar
+
+	ctx, msg := codec.WithNewMessage(context.Background())
+	msg.WithClientRPCName("/")
+	msg.WithClientReqHead(&thttp.ClientReqHeader{})
+	rspHeader := &thttp.ClientRspHeader{}
+	msg.WithClientRspHead(rspHeader)
+
+	_, err = ct.RoundTrip(ctx, nil,
+		transport.WithDialAddress(u.Host),
+		transport.WithDialTLS("", "", "none", ""),
+	)
+	require.NoError(t, err)
+	require.NotNil(t, rspHeader.Response)
+	defer rspHeader.Response.Body.Close()
+
+	cookies := jar.Cookies(u)
+	require.Len(t, cookies, 1)
+	require.Equal(t, "sid", cookies[0].Name)
+	require.Equal(t, "cookie-value", cookies[0].Value)
 }
 
 func TestListenAndServeHTTPHead(t *testing.T) {


### PR DESCRIPTION
## Summary
- Preserve the configured http.Client CookieJar when constructing TLS-specific HTTP clients.
- Add regression coverage for CookieJar handling on TLS requests.

## Tests
- go test ./http -run TestTLSClientInheritsCookieJar -count=1
- go test ./http -count=1
- go test ./... -count=1

Close #202
