### PR TITLE
http: export default serialization tag

### DIFF
--- a/http/serialization_form.go
+++ b/http/serialization_form.go
@@ -23,13 +23,13 @@ import (
 	"github.com/mitchellh/mapstructure"
 )
 
-// Uses the same tag as json.
-var tag = "json"
+// DefaultSerializationTag is the default struct tag used by HTTP serializers.
+const DefaultSerializationTag = "json"
 
 func init() {
 	codec.RegisterSerializer(
 		codec.SerializationTypeForm,
-		NewFormSerialization(tag),
+		NewFormSerialization(DefaultSerializationTag),
 	)
 }
 

--- a/http/serialization_form_data.go
+++ b/http/serialization_form_data.go
@@ -21,8 +21,6 @@ import (
 )
 
 var (
-	// tagJSON uses same tag with json.
-	tagJSON = "json"
 	// FormDataMarshalType the serialization method of the response data,
 	// default is json serialization.
 	FormDataMarshalType = codec.SerializationTypeJSON
@@ -31,7 +29,7 @@ var (
 func init() {
 	codec.RegisterSerializer(
 		codec.SerializationTypeFormData,
-		NewFormDataSerialization(tagJSON),
+		NewFormDataSerialization(DefaultSerializationTag),
 	)
 }
 

--- a/http/serialization_form_test.go
+++ b/http/serialization_form_test.go
@@ -38,7 +38,7 @@ func TestFormSerializerRegister(t *testing.T) {
 	defer func() {
 		codec.RegisterSerializer(codec.SerializationTypeForm, s)
 	}()
-	codec.RegisterSerializer(codec.SerializationTypeForm, http.NewFormSerialization("json"))
+	codec.RegisterSerializer(codec.SerializationTypeForm, http.NewFormSerialization(http.DefaultSerializationTag))
 	formSerializer := codec.GetSerializer(codec.SerializationTypeForm)
 	require.NotNil(t, formSerializer)
 }

--- a/http/serialization_get.go
+++ b/http/serialization_get.go
@@ -21,7 +21,7 @@ import (
 )
 
 func init() {
-	codec.RegisterSerializer(codec.SerializationTypeGet, NewGetSerialization(tag))
+	codec.RegisterSerializer(codec.SerializationTypeGet, NewGetSerialization(DefaultSerializationTag))
 }
 
 // NewGetSerialization initializes the get serialized object.

--- a/http/serialization_get_test.go
+++ b/http/serialization_get_test.go
@@ -32,7 +32,7 @@ func TestGetSerializerRegister(t *testing.T) {
 	defer func() {
 		codec.RegisterSerializer(codec.SerializationTypeGet, s)
 	}()
-	codec.RegisterSerializer(codec.SerializationTypeGet, http.NewGetSerialization("json"))
+	codec.RegisterSerializer(codec.SerializationTypeGet, http.NewGetSerialization(http.DefaultSerializationTag))
 	serializer := codec.GetSerializer(codec.SerializationTypeGet)
 	require.NotNil(t, serializer)
 }
@@ -158,7 +158,8 @@ func TestGetSerializationCaseSensitive(t *testing.T) {
 		require.Equal(t, "hello", req.Msg)
 	}
 
-	codec.RegisterSerializer(codec.SerializationTypeGet, http.NewGetSerializationWithCaseSensitive("json", true))
+	codec.RegisterSerializer(codec.SerializationTypeGet,
+		http.NewGetSerializationWithCaseSensitive(http.DefaultSerializationTag, true))
 	s = codec.GetSerializer(codec.SerializationTypeGet)
 
 	req := &helloReq{}


### PR DESCRIPTION
## Summary
- export `http.DefaultSerializationTag` for the default struct tag used by HTTP form and query serializers
- replace duplicate private tag constants/usages with the exported constant
- update serializer tests to assert against the shared constant

## Behavior
- the default tag value remains `json`
- form, multipart form, and GET query serialization keep the same behavior
- callers that need to align custom HTTP serialization with the built-in default can now reference the constant directly

## Compatibility
- additive API only; no existing API is removed or changed
- no dependency changes
- no private links, internal endpoints, or local environment details are introduced

## Validation
- `go test ./http -count=1`