### PR TITLE
restful: cap pooled body buffers

### DIFF
--- a/restful/transcode.go
+++ b/restful/transcode.go
@@ -32,6 +32,8 @@ import (
 const (
 	// default size of http req body buffer
 	defaultBodyBufferSize = 4096
+	// maxPooledBodyBufferSize is the largest http request body buffer kept in pool.
+	maxPooledBodyBufferSize = 1 << 20
 )
 
 // transcoder is for tRPC/httpjson transcoding.
@@ -133,6 +135,18 @@ var bodyBufferPool = sync.Pool{
 	},
 }
 
+// putBackBodyBuffer puts a body buffer back to the pool.
+func putBackBodyBuffer(buffer *bytes.Buffer) {
+	if buffer == nil {
+		return
+	}
+	if buffer.Cap() > maxPooledBodyBufferSize {
+		return
+	}
+	buffer.Reset()
+	bodyBufferPool.Put(buffer)
+}
+
 // transcodeBody transcodes tRPC/httpjson by http request body.
 func (tr *transcoder) transcodeBody(protoReq proto.Message, body io.Reader, c Compressor, s Serializer) error {
 	// HttpRule body is not specified
@@ -154,7 +168,7 @@ func (tr *transcoder) transcodeBody(protoReq proto.Message, body io.Reader, c Co
 	// read body
 	buffer := bodyBufferPool.Get().(*bytes.Buffer)
 	buffer.Reset()
-	defer bodyBufferPool.Put(buffer)
+	defer putBackBodyBuffer(buffer)
 	if _, err := io.Copy(buffer, reader); err != nil {
 		return fmt.Errorf("failed to read request body: %w", err)
 	}

--- a/restful/transcode_test.go
+++ b/restful/transcode_test.go
@@ -1,0 +1,50 @@
+//
+//
+// Tencent is pleased to support the open source community by making tRPC available.
+//
+// Copyright (C) 2023 Tencent.
+// All rights reserved.
+//
+// If you have downloaded a copy of the tRPC source code from Tencent,
+// please note that tRPC source code is licensed under the  Apache 2.0 License,
+// A copy of the Apache 2.0 License is included in this file.
+//
+//
+
+package restful
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPutBackBodyBufferNilSafe(t *testing.T) {
+	require.NotPanics(t, func() {
+		putBackBodyBuffer(nil)
+	})
+}
+
+func TestPutBackBodyBufferKeepsSmallBuffer(t *testing.T) {
+	buffer := bytes.NewBufferString("payload")
+	require.LessOrEqual(t, buffer.Cap(), maxPooledBodyBufferSize)
+
+	putBackBodyBuffer(buffer)
+
+	require.Zero(t, buffer.Len())
+	got := bodyBufferPool.Get().(*bytes.Buffer)
+	putBackBodyBuffer(got)
+}
+
+func TestPutBackBodyBufferDropsOversizedBuffer(t *testing.T) {
+	buffer := bodyBufferPool.Get().(*bytes.Buffer)
+	buffer.Grow(maxPooledBodyBufferSize + 1)
+	putBackBodyBuffer(buffer)
+
+	for i := 0; i < 8; i++ {
+		got := bodyBufferPool.Get().(*bytes.Buffer)
+		require.NotSame(t, buffer, got)
+		putBackBodyBuffer(got)
+	}
+}


### PR DESCRIPTION
## Summary
- cap the size of `restful` request body buffers that are returned to the pool
- drop oversized buffers instead of retaining their backing arrays across future requests
- add focused tests for nil, normal-sized, and oversized buffer paths

## Behavior
- normal request bodies continue to reuse pooled buffers
- buffers larger than 1 MiB are allowed for the current request but are not returned to the pool afterward
- request decoding and response behavior are unchanged

## Compatibility
- no public API changes
- the cap only affects internal buffer reuse after a request has been read
- large requests may allocate a fresh buffer on subsequent requests, trading reuse for bounded retained memory
- no dependency changes or private/internal references are introduced

## Validation
- `go test ./restful -count=1`
- `go test ./... -count=1`