### PR TITLE
client: avoid private IP in prewarm tests

### DIFF
--- a/client/pre_warm_test.go
+++ b/client/pre_warm_test.go
@@ -31,6 +31,8 @@ import (
 	"trpc.group/trpc-go/trpc-go/transport"
 )
 
+const preWarmAddress = "prewarm.example.test:8000"
+
 func TestInitializableClientPreWarm(t *testing.T) {
 	cli, ok := client.New().(client.InitializableClient)
 	require.True(t, ok)
@@ -41,7 +43,7 @@ func TestInitializableClientPreWarm(t *testing.T) {
 		client.WithPool(pool),
 		client.WithPreWarm(transport.PreWarmOptions{ConnsPerNode: 2}),
 	))
-	require.Equal(t, []string{"10.0.0.1:8000", "10.0.0.1:8000"}, pool.addresses)
+	require.Equal(t, []string{preWarmAddress, preWarmAddress}, pool.addresses)
 }
 
 func TestInitializableClientPreWarmDisabled(t *testing.T) {
@@ -87,7 +89,7 @@ type preWarmSelector struct{}
 
 func (preWarmSelector) Select(serviceName string, _ ...selector.Option) (*registry.Node, error) {
 	if serviceName == "backend" {
-		return &registry.Node{Network: "tcp", Address: "10.0.0.1:8000"}, nil
+		return &registry.Node{Network: "tcp", Address: preWarmAddress}, nil
 	}
 	return nil, errors.New("unknown service")
 }


### PR DESCRIPTION
## Summary

- Replace the private IPv4 literal in prewarm client tests with a reserved test hostname.
- Reuse one fixture constant for the selector result and assertion.

## Motivation

The test only verifies that prewarming passes the selected endpoint into the connection pool. It does not need a private network address, and using a reserved test hostname avoids static scanner findings without changing runtime behavior.

## Validation

- go test ./client -run PreWarm -count=1
