### PR TITLE
restful: wrap custom routes with server filters

### DIFF
--- a/restful/README.md
+++ b/restful/README.md
@@ -664,6 +664,30 @@ func main() {
 }
 ```
 
+Custom routes registered this way keep the historical behavior: only pb-defined
+RESTful routes run the service server filter chain. If the custom routes should
+also run the filters configured for the service, wrap the handler before
+registering it:
+
+```go
+router := restful.GetRouter(pb.PingServer_ServiceDesc.ServiceName)
+mux := http.NewServeMux()
+mux.Handle("/", router)
+mux.HandleFunc("/custom/ping", customPingHandler)
+
+restful.RegisterRouter(
+    pb.PingServer_ServiceDesc.ServiceName,
+    restful.WrapHandlerWithServerFilters(pb.PingServer_ServiceDesc.ServiceName, mux),
+)
+```
+
+`WrapHandlerWithServerFilters` is opt-in and preserves pb route behavior. Pb
+routes still go through the native transcoder path with typed request and
+response values, while custom non-pb routes run the server filter chain with a
+nil request value before the wrapped handler is invoked. The pb service must be
+registered first so the wrapper can reuse the framework-created RESTful router
+for route matching and filter extraction.
+
 # Performance
 
 To improve performance, the RESTful protocol plugin also supports handling HTTP packets based on [fasthttp](https://github.com/valyala/fasthttp). 

--- a/restful/README.zh_CN.md
+++ b/restful/README.zh_CN.md
@@ -602,6 +602,28 @@ func main() {
 }
 ```
 
+这种自定义路由默认保持历史行为：只有 pb 定义的 RESTful 路由会执行
+service 的 server filter 链。如果希望自定义路由也执行该 service 上配置的
+filter，可以在重新注册 handler 前先包装一层：
+
+```go
+router := restful.GetRouter(pb.PingServer_ServiceDesc.ServiceName)
+mux := http.NewServeMux()
+mux.Handle("/", router)
+mux.HandleFunc("/custom/ping", customPingHandler)
+
+restful.RegisterRouter(
+    pb.PingServer_ServiceDesc.ServiceName,
+    restful.WrapHandlerWithServerFilters(pb.PingServer_ServiceDesc.ServiceName, mux),
+)
+```
+
+`WrapHandlerWithServerFilters` 是显式 opt-in，不改变 pb 路由行为。pb 路由
+仍然走原生 transcoder 路径，filter 看到的仍是类型化的请求和响应；自定义
+非 pb 路由会在进入被包装 handler 前，以 nil 请求值执行 server filter 链。
+调用 wrapper 前必须先注册 pb service，这样 wrapper 才能复用框架创建的
+RESTful router 来做路由匹配和 filter 提取。
+
 # 性能
 
 为了提升性能，RESTful 协议插件额外支持基于 [fasthttp](https://github.com/valyala/fasthttp) 来处理 HTTP 包，RESTful 协议插件性能和注册的 URL 路径复杂度有关，和通过哪种方式传递 PB Message 字段也有关，这里仅给出最简单的 echo 测试场景下两种模式的对比：

--- a/restful/router.go
+++ b/restful/router.go
@@ -80,6 +80,64 @@ func GetRouter(name string) http.Handler {
 	return router
 }
 
+// WrapHandlerWithServerFilters wraps an http.Handler so custom, non-pb routes
+// pass through the service-level server filter chain configured for the RESTful
+// service. Pb-mapped RESTful routes bypass this wrapper and keep the native
+// transcoder filter path with typed request and response values.
+//
+// The pb service must be registered before calling this function because the
+// wrapper sources filters and route matching from the framework-created
+// *restful.Router for the service.
+func WrapHandlerWithServerFilters(name string, h http.Handler) http.Handler {
+	orig := mustGetRouterForServerFilterWrapper(name)
+	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		if orig.matchesRESTfulRoute(req) {
+			h.ServeHTTP(w, req)
+			return
+		}
+
+		ctx := req.Context()
+		if ctxForCompatibility != nil {
+			ctx = ctxForCompatibility(ctx, w, req)
+		}
+		ctx, err := orig.opts.HeaderMatcher(ctx, w, req, orig.opts.ServiceName, req.URL.Path)
+		if err != nil {
+			putBackCtxMessage(ctx)
+			orig.opts.ErrorHandler(ctx, w, req, errs.New(errs.RetServerDecodeFail, err.Error()))
+			return
+		}
+		defer putBackCtxMessage(ctx)
+
+		var filters filter.ServerChain
+		if orig.opts.FilterFunc != nil {
+			filters = orig.opts.FilterFunc()
+		}
+		if _, err := filters.Filter(ctx, nil, func(ctx context.Context, _ interface{}) (interface{}, error) {
+			filteredReq := req.WithContext(ctx)
+			h.ServeHTTP(w, filteredReq)
+			if req.MultipartForm == nil {
+				req.MultipartForm = filteredReq.MultipartForm
+			}
+			return nil, nil
+		}); err != nil {
+			orig.opts.ErrorHandler(ctx, w, req, err)
+		}
+	})
+}
+
+func mustGetRouterForServerFilterWrapper(name string) *Router {
+	router := GetRouter(name)
+	orig, ok := router.(*Router)
+	if !ok {
+		panic(fmt.Sprintf(
+			"restful: WrapHandlerWithServerFilters requires the original *restful.Router "+
+				"to be registered before wrapping service %q; current router is %T",
+			name, router,
+		))
+	}
+	return orig
+}
+
 // ProtoMessage is alias of proto.Message.
 type ProtoMessage proto.Message
 
@@ -324,6 +382,11 @@ func (r *Router) findTranscoder(method, path string) (*transcoder, map[string]st
 		}
 	}
 	return nil, nil
+}
+
+func (r *Router) matchesRESTfulRoute(req *http.Request) bool {
+	tr, _ := r.findTranscoder(req.Method, req.URL.Path)
+	return tr != nil
 }
 
 func (r *Router) handle(

--- a/restful/router_filter_test.go
+++ b/restful/router_filter_test.go
@@ -1,0 +1,153 @@
+//
+//
+// Tencent is pleased to support the open source community by making tRPC available.
+//
+// Copyright (C) 2023 Tencent.
+// All rights reserved.
+//
+// If you have downloaded a copy of the tRPC source code from Tencent,
+// please note that tRPC source code is licensed under the  Apache 2.0 License,
+// A copy of the Apache 2.0 License is included in this file.
+//
+//
+
+package restful_test
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"trpc.group/trpc-go/trpc-go/codec"
+	"trpc.group/trpc-go/trpc-go/filter"
+	"trpc.group/trpc-go/trpc-go/restful"
+	"trpc.group/trpc-go/trpc-go/server"
+	"trpc.group/trpc-go/trpc-go/testdata/restful/helloworld"
+)
+
+type filterCounts struct {
+	total         int32
+	pbRoute       int32
+	customRoute   int32
+	customRPCName atomic.Value
+}
+
+func (c *filterCounts) filter(ctx context.Context, req interface{}, next filter.ServerHandleFunc) (
+	interface{}, error,
+) {
+	atomic.AddInt32(&c.total, 1)
+	if _, ok := req.(*helloworld.HelloRequest); ok {
+		atomic.AddInt32(&c.pbRoute, 1)
+	}
+	if req == nil {
+		atomic.AddInt32(&c.customRoute, 1)
+		c.customRPCName.Store(codec.Message(ctx).ServerRPCName())
+	}
+	return next(ctx, req)
+}
+
+func TestRegisterRouterDefaultBypassesCustomRouteFilters(t *testing.T) {
+	addr, counts := startRESTfulMuxServer(t, false)
+
+	body := doGET(t, addr+"/v2/bar/world", http.StatusOK)
+	require.Equal(t, `{"message":"world"}`, body)
+	require.Equal(t, int32(1), atomic.LoadInt32(&counts.total))
+	require.Equal(t, int32(1), atomic.LoadInt32(&counts.pbRoute))
+
+	body = doGET(t, addr+"/custom/ping", http.StatusOK)
+	require.Equal(t, "pong", body)
+	require.Equal(t, int32(1), atomic.LoadInt32(&counts.total))
+	require.Equal(t, int32(0), atomic.LoadInt32(&counts.customRoute))
+}
+
+func TestWrapHandlerWithServerFilters(t *testing.T) {
+	addr, counts := startRESTfulMuxServer(t, true)
+
+	body := doGET(t, addr+"/v2/bar/world", http.StatusOK)
+	require.Equal(t, `{"message":"world"}`, body)
+	require.Equal(t, int32(1), atomic.LoadInt32(&counts.total))
+	require.Equal(t, int32(1), atomic.LoadInt32(&counts.pbRoute))
+	require.Equal(t, int32(0), atomic.LoadInt32(&counts.customRoute))
+
+	body = doGET(t, addr+"/custom/ping", http.StatusOK)
+	require.Equal(t, "pong", body)
+	require.Equal(t, int32(2), atomic.LoadInt32(&counts.total))
+	require.Equal(t, int32(1), atomic.LoadInt32(&counts.pbRoute))
+	require.Equal(t, int32(1), atomic.LoadInt32(&counts.customRoute))
+	require.Equal(t, "/custom/ping", counts.customRPCName.Load())
+}
+
+func TestWrapHandlerWithServerFiltersPanicsWithoutRouter(t *testing.T) {
+	require.PanicsWithValue(t,
+		fmt.Sprintf("restful: WrapHandlerWithServerFilters requires the original *restful.Router "+
+			"to be registered before wrapping service %q; current router is %T", t.Name(), nil),
+		func() {
+			restful.WrapHandlerWithServerFilters(t.Name(), http.NewServeMux())
+		},
+	)
+}
+
+func startRESTfulMuxServer(t *testing.T, wrap bool) (string, *filterCounts) {
+	t.Helper()
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	counts := &filterCounts{}
+	serviceName := t.Name()
+	s := server.New(
+		server.WithListener(ln),
+		server.WithServiceName(serviceName),
+		server.WithNetwork("tcp"),
+		server.WithProtocol("restful"),
+		server.WithFilter(counts.filter),
+	)
+	RegisterGreeterService(s, &greeter{})
+
+	router := restful.GetRouter(serviceName)
+	require.NotNil(t, router)
+	mux := http.NewServeMux()
+	mux.Handle("/", router)
+	mux.HandleFunc("/custom/ping", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("pong"))
+	})
+
+	handler := http.Handler(mux)
+	if wrap {
+		handler = restful.WrapHandlerWithServerFilters(serviceName, mux)
+	}
+	restful.RegisterRouter(serviceName, handler)
+
+	errCh := make(chan error, 1)
+	go func() { errCh <- s.Serve() }()
+	select {
+	case err := <-errCh:
+		require.FailNow(t, "serve failed", err)
+	case <-time.After(200 * time.Millisecond):
+	}
+	t.Cleanup(func() {
+		s.Close(nil)
+		_ = ln.Close()
+	})
+	return "http://" + ln.Addr().String(), counts
+}
+
+func doGET(t *testing.T, url string, wantStatus int) string {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	require.NoError(t, err)
+	rsp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer rsp.Body.Close()
+	require.Equal(t, wantStatus, rsp.StatusCode)
+	body, err := io.ReadAll(rsp.Body)
+	require.NoError(t, err)
+	return string(body)
+}


### PR DESCRIPTION
## What

- Add `restful.WrapHandlerWithServerFilters` for custom net/http routes registered through `restful.RegisterRouter`.
- Keep pb-mapped RESTful routes on the native transcoder filter path to avoid double filtering and preserve typed request/response values.
- Document the opt-in usage in the RESTful README files.
- Add tests for the default bypass behavior, opt-in custom route filtering, pb route double-filter guard, and ordering panic.

## Compatibility

The default `RegisterRouter` behavior is unchanged. Custom routes only enter the server filter chain when users explicitly wrap their handler. Existing pb RESTful routes continue to run through the original transcoder path.

## Tests

- `go test ./... -count=1`
- `go test ./restful -count=1`
- `go test ./restful -run 'TestRegisterRouterDefaultBypassesCustomRouteFilters|TestWrapHandlerWithServerFilters' -count=1 -v`
- `go test ./http ./server -count=1`
- `go run github.com/golangci/golangci-lint/cmd/golangci-lint@v1.64.8 run --new-from-rev=upstream/main`
