### PR TITLE
docs: fix client overview examples

### DIFF
--- a/docs/user_guide/client/overview.md
+++ b/docs/user_guide/client/overview.md
@@ -91,7 +91,7 @@ func (s *greeterServerImpl) SayHello(ctx context.Context, req *pb.HelloRequest) 
         log.ErrorContextf(ctx, "say hi fail:%v", err)
         return nil, errs.New(10000, "xxxxx") 
     }
-    return &pb.HelloReply{Xxx: reply.Xxx} nil
+    return &pb.HelloReply{Xxx: reply.Xxx}, nil
 }
 
 func main(){
@@ -119,7 +119,7 @@ import (
 )
 
 // Generally, small tools start from the main function
-func main {
+func main() {
     // Since there is no configuration file to help initialize the plugin, you need to manually initialize the North Star
     pselector.RegisterDefault()
     // Create a client call proxy

--- a/docs/user_guide/client/overview.zh_CN.md
+++ b/docs/user_guide/client/overview.zh_CN.md
@@ -94,7 +94,7 @@ func (s *greeterServerImpl) SayHello(ctx context.Context, req *pb.HelloRequest) 
         log.ErrorContextf(ctx, "say hi fail:%v", err)
         return nil, errs.New(10000, "xxxxx") 
     }
-    return &pb.HelloReply{Xxx: reply.Xxx} nil
+    return &pb.HelloReply{Xxx: reply.Xxx}, nil
 }
 
 func main(){
@@ -122,7 +122,7 @@ import (
 )
 
 // 一般小工具都是从 main 函数写起
-func main {
+func main() {
     // 由于没有配置文件帮忙初始化插件，所以需要自己手动初始化北极星
     pselector.RegisterDefault()
     // 创建一个客户端调用代理


### PR DESCRIPTION
## Summary

- Fix a missing comma in the client overview service example.
- Fix the pure-client `main` function declaration in the English and Chinese docs.

## Why

These snippets are illustrative, but the syntax errors make them harder to copy and adapt.

## Tests

- `git diff --check`
